### PR TITLE
Add cost switch to recipes command

### DIFF
--- a/commands/commands/crafting.py
+++ b/commands/commands/crafting.py
@@ -842,11 +842,11 @@ class CmdRecipes(ArxCommand):
                 return
             match = match[0]
             cost = 0 if caller.check_permstring('builders') else match.additional_cost
-            cost_msg = "It costs %s for you to learn %s." % (cost or "nothing", match.name)
+            cost_msg = "It will cost %s for you to learn %s." % (cost or "nothing", match.name)
             if 'cost' in self.switches:
                 return caller.msg(cost_msg)
             elif cost > caller.db.currency:
-                return caller.msg("%s You only have %s silver." % (cost_msg, caller.db.currency))
+                return caller.msg("%s You have %s silver." % (cost_msg, caller.db.currency))
             caller.pay_money(cost)
             dompc.assets.recipes.add(match)
             coststr = (" for %s silver" % cost) if cost else ""

--- a/commands/commands/crafting.py
+++ b/commands/commands/crafting.py
@@ -836,7 +836,7 @@ class CmdRecipes(ArxCommand):
             if self.args:
                 match = [ob for ob in can_learn if ob.name.lower() == self.args.lower()]
             if not match:
-                learn_msg = ("You cannot learn '%s'. " % self.rhs) if self.rhs else ""
+                learn_msg = ("You cannot learn '%s'. " % self.lhs) if self.lhs else ""
                 caller.msg("%sRecipes you can learn:" % learn_msg)
                 self.display_recipes(can_learn)
                 return

--- a/commands/commands/crafting.py
+++ b/commands/commands/crafting.py
@@ -845,8 +845,8 @@ class CmdRecipes(ArxCommand):
             cost_msg = "It will cost %s for you to learn %s." % (cost or "nothing", match.name)
             if 'cost' in self.switches:
                 return caller.msg(cost_msg)
-            elif cost > caller.db.currency:
-                return caller.msg("%s You have %s silver." % (cost_msg, caller.db.currency))
+            elif cost > caller.currency:
+                return caller.msg("You have %s silver. %s" % (caller.currency, cost_msg))
             caller.pay_money(cost)
             dompc.assets.recipes.add(match)
             coststr = (" for %s silver" % cost) if cost else ""

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -31,7 +31,7 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
                                   self.recipe5, self.recipe7])
         self.call_cmd("tailor", "")
         rtable.assert_called_with([self.recipe1])
-        self.call_cmd("/known" "")
+        self.call_cmd("/known", "")
         rtable.assert_called_with([self.recipe6])
         self.match_recipe_locks_to_level()  # recipe locks become level-appropriate
         self.call_cmd("", "")

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -48,6 +48,8 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/teach Char=Mask", "Taught Char Mask.")
         self.assertEqual(list(self.char.dompc.assets.recipes.all()), [self.recipe6])
         self.call_cmd("/teach Char=Mask", "They already know Mask.")
+        self.recipe5.locks.replace("teach:all();learn:all()")
+        self.recipe5.save()
         self.caller = self.char  # Char is staff
         self.call_cmd("/cost Hairpins", "It will cost nothing for you to learn Hairpins.")
 

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -16,10 +16,12 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.setup_cmd(crafting.CmdRecipes, self.char2)
         self.call_cmd("/cost Bag", "It will cost nothing for you to learn Bag.")
         self.add_recipe_additional_costs(10)
-        self.call_cmd("/learn Mask", "It will cost 10 for you to learn Mask. You have 0 silver.")
+        self.char2.currency = 1
+        self.call_cmd("/learn Mask", "You have 1 silver. It will cost 10 for you to learn Mask.")
         self.char2.currency = 100
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
-        self.assertEqual([self.char2.assets.recipes], [self.recipe6])
+        slysets = self.account2.dompc.assets
+        self.assertEqual([slysets.recipes.all()], [self.recipe6])
         self.assertEqual(self.char2.currency, 90)
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -15,16 +15,16 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
     def test_cmd_recipes(self):
         self.setup_cmd(crafting.CmdRecipes, self.char2)
         self.add_recipe_additional_costs(10)
-        self.call_cmd("", "Know Name          Ability       Difficulty Cost"
-                          "     Mask          apothecary    4          10"
-                          "     Bag           leatherworker 5          10"
-                          "     Top 2 Slot    leatherworker 6          10"
-                          "     Top 1 Slot    tailor        5          10"
-                          "     Hairpins      weaponsmith   4          10"
-                          "     Medium Weapon weaponsmith   4          10"
-                          "     Small Weapon  weaponsmith   4          10")
-        self.call_cmd("tailor", "Know Name       Ability Difficulty Cost"
-                                "     Top 1 Slot tailor  5          10")
+        self.call_cmd("", "Known Name          Ability       Lvl Cost     \n"
+                          "      Mask          apothecary    4   10"
+                          "      Bag           leatherworker 5   10"
+                          "      Top 2 Slot    leatherworker 6   10"
+                          "      Top 1 Slot    tailor        5   10"
+                          "      Hairpins      weaponsmith   4   10"
+                          "      Medium Weapon weaponsmith   4   10"
+                          "      Small Weapon  weaponsmith   4   10")
+        self.call_cmd("tailor", "Known Name       Ability Lvl Cost"
+                                "      Top 1 Slot tailor  5   10")
         self.call_cmd("/cost Bag", "It costs 10 for you to learn Bag.")
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         self.call_cmd("/learn Mask", "It costs 10 for you to learn Mask. You only have 0 silver.")
@@ -32,26 +32,23 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
         self.assertEqual([self.char2.assets.recipes], [self.recipe6])
         self.assertEqual(self.char2.currency, 90)
-        self.call_cmd("/known" "Know Name Ability    Difficulty Cost"
-                               "X    Mask apothecary 4          10")
-        self.recipe3.locks.add("learn: ability(5)")
-        self.recipe3.save()
-        self.call_cmd("/learn Bag", "No learnable recipe by that name. Recipes you can learn:|"
-                                    "Know Name          Ability       Difficulty Cost"
-                                    "     Top 2 Slot    leatherworker 6          10"
-                                    "     Top 1 Slot    tailor        5          10"
-                                    "     Hairpins      weaponsmith   4          10"
-                                    "     Medium Weapon weaponsmith   4          10"
-                                    "     Small Weapon  weaponsmith   4          10")
-        self.recipe6.locks.add("learn: ability(4)")
+        self.call_cmd("/known" "Known Name Ability    Lvl Cost"
+                               "X     Mask apothecary 4   10")
+        self.match_recipe_locks_to_level()  # recipe locks become level-appropriate
+        self.call_cmd("/learn Bag", "You cannot learn 'Bag'. Recipes you can learn:|"
+                                    "(No recipes qualify.)")
+        self.call_cmd("/teach Char=Mask", "You cannot teach 'Mask'. Recipes you can teach:|"
+                                          "(No recipes qualify.)")
+        self.recipe6.locks.replace("teach:all();learn: ability(4)")
         self.recipe6.save()
         self.call_cmd("/teach Char=Mask", "They cannot learn Mask.")
-        self.recipe6.locks.clear()
+        self.recipe6.locks.replace("teach:all();learn:all()")
+        self.recipe6.save()
         self.call_cmd("/teach Char=Mask", "Taught Char Mask.")
         self.assertEqual([self.char.assets.recipes], [self.recipe6])
         self.call_cmd("/teach Char=Mask", "They already know Mask.")
-        self.caller = self.char  # staff
-        self.call_cmd("/cost Bag", "It costs nothing for you to learn Bag.")
+        self.caller = self.char  # Char is staff
+        self.call_cmd("/cost Hairpins", "It costs nothing for you to learn Hairpins.")
 
 
 class StoryActionTests(ArxCommandTest):

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -15,6 +15,7 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
     def test_cmd_recipes(self):
         self.setup_cmd(crafting.CmdRecipes, self.char2)
         self.add_recipe_additional_costs(10)
+        self.call_cmd("/cost Bag", "It costs 10 for you to learn Bag.")
         self.call_cmd("", "Known Name          Ability       Lvl Cost     \n"
                           "      Mask          apothecary    4   10"
                           "      Bag           leatherworker 5   10"
@@ -25,7 +26,6 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
                           "      Small Weapon  weaponsmith   4   10")
         self.call_cmd("tailor", "Known Name       Ability Lvl Cost"
                                 "      Top 1 Slot tailor  5   10")
-        self.call_cmd("/cost Bag", "It costs 10 for you to learn Bag.")
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         self.call_cmd("/learn Mask", "It costs 10 for you to learn Mask. You only have 0 silver.")
         self.char2.currency = 100

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -22,7 +22,8 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
         self.assertEqual(list(self.char2.dompc.assets.recipes.all()), [self.recipe6])
         self.assertEqual(self.char2.currency, 90.0)
-        self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
+        self.call_cmd("/info Mask", "Name: Mask\nDescription: None\nSilver: 10\nPrimary Materials:\n"
+                                    "Mat1: 4 (0/4)")
         # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables
         self.call_cmd("/learn", "Recipes you can learn:|"
                                 "Known Name          Ability       Lvl Cost     \n"

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -20,7 +20,7 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/learn Mask", "You have 1.0 silver. It will cost 10 for you to learn Mask.")
         self.char2.currency = 100
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
-        self.assertEqual([self.char2.dompc.assets.recipes.all()], [self.recipe6])
+        self.assertEqual(list(self.char2.dompc.assets.recipes.all()), [self.recipe6])
         self.assertEqual(self.char2.currency, 90.0)
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -20,8 +20,7 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/learn Mask", "You have 1.0 silver. It will cost 10 for you to learn Mask.")
         self.char2.currency = 100
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
-        slysets = self.account2.dompc.assets
-        self.assertEqual([slysets.recipes.all()], [self.recipe6])
+        self.assertEqual([self.char2.dompc.assets.recipes.all()], [self.recipe6])
         self.assertEqual(self.char2.currency, 90.0)
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -17,12 +17,12 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.call_cmd("/cost Bag", "It will cost nothing for you to learn Bag.")
         self.add_recipe_additional_costs(10)
         self.char2.currency = 1
-        self.call_cmd("/learn Mask", "You have 1 silver. It will cost 10 for you to learn Mask.")
+        self.call_cmd("/learn Mask", "You have 1.0 silver. It will cost 10 for you to learn Mask.")
         self.char2.currency = 100
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
         slysets = self.account2.dompc.assets
         self.assertEqual([slysets.recipes.all()], [self.recipe6])
-        self.assertEqual(self.char2.currency, 90)
+        self.assertEqual(self.char2.currency, 90.0)
         self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
         # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables
         self.call_cmd("/learn", "Recipes you can learn:|"
@@ -53,7 +53,7 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
         self.assertEqual([self.char.assets.recipes], [self.recipe6])
         self.call_cmd("/teach Char=Mask", "They already know Mask.")
         self.caller = self.char  # Char is staff
-        self.call_cmd("/cost Hairpins", "It costs nothing for you to learn Hairpins.")
+        self.call_cmd("/cost Hairpins", "It will cost nothing for you to learn Hairpins.")
 
 
 class StoryActionTests(ArxCommandTest):

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -14,27 +14,30 @@ class CraftingTests(TestEquipmentMixins, ArxCommandTest):
 
     def test_cmd_recipes(self):
         self.setup_cmd(crafting.CmdRecipes, self.char2)
+        self.call_cmd("/cost Bag", "It will cost nothing for you to learn Bag.")
         self.add_recipe_additional_costs(10)
-        self.call_cmd("/cost Bag", "It costs 10 for you to learn Bag.")
-        self.call_cmd("", "Known Name          Ability       Lvl Cost     \n"
-                          "      Mask          apothecary    4   10"
-                          "      Bag           leatherworker 5   10"
-                          "      Top 2 Slot    leatherworker 6   10"
-                          "      Top 1 Slot    tailor        5   10"
-                          "      Hairpins      weaponsmith   4   10"
-                          "      Medium Weapon weaponsmith   4   10"
-                          "      Small Weapon  weaponsmith   4   10")
-        self.call_cmd("tailor", "Known Name       Ability Lvl Cost"
-                                "      Top 1 Slot tailor  5   10")
-        self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
-        self.call_cmd("/learn Mask", "It costs 10 for you to learn Mask. You only have 0 silver.")
+        self.call_cmd("/learn Mask", "It will cost 10 for you to learn Mask. You have 0 silver.")
         self.char2.currency = 100
         self.call_cmd("/learn Mask", "You have learned Mask for 10 silver.")
         self.assertEqual([self.char2.assets.recipes], [self.recipe6])
         self.assertEqual(self.char2.currency, 90)
+        self.call_cmd("/info Mask", "3 baffled raccoons in a display table")
+        # TODO: Pretty sure I have to mock arx_more and use assert_called_with for these tables
+        self.call_cmd("/learn", "Recipes you can learn:|"
+                                "Known Name          Ability       Lvl Cost     \n"
+                                "      Bag           leatherworker 5   10"
+                                "      Top 2 Slot    leatherworker 6   10"
+                                "      Top 1 Slot    tailor        5   10"
+                                "      Hairpins      weaponsmith   4   10"
+                                "      Medium Weapon weaponsmith   4   10"
+                                "      Small Weapon  weaponsmith   4   10")
+        self.call_cmd("tailor", "Known Name       Ability Lvl Cost"
+                                "      Top 1 Slot tailor  5   10")
         self.call_cmd("/known" "Known Name Ability    Lvl Cost"
                                "X     Mask apothecary 4   10")
         self.match_recipe_locks_to_level()  # recipe locks become level-appropriate
+        self.call_cmd("", "Known Name Ability    Lvl Cost     \n"
+                          "X     Mask apothecary 4   10")
         self.call_cmd("/learn Bag", "You cannot learn 'Bag'. Recipes you can learn:|"
                                     "(No recipes qualify.)")
         self.call_cmd("/teach Char=Mask", "You cannot teach 'Mask'. Recipes you can teach:|"

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -117,13 +117,15 @@ class ArxCommandTest(ArxTestConfigMixin, CommandTest):
     """
     cmd_class = None
     caller = None
+    instance = None
 
     def setup_cmd(self, cmd_cls, caller):
         self.cmd_class = cmd_cls
         self.caller = caller
+        self.instance = self.cmd_class()
 
     def call_cmd(self, args, msg, **kwargs):
-        self.call(self.cmd_class(), args, msg, caller=self.caller, **kwargs)
+        self.call(self.instance, args, msg, caller=self.caller, **kwargs)
 
     # noinspection PyBroadException
     def call(self, cmdobj, args, msg=None, cmdset=None, noansi=True, caller=None, receiver=None, cmdstring=None,
@@ -244,8 +246,8 @@ class TestEquipmentMixins(object):
         self.recipe7 = CraftingRecipe.objects.create(name="Medium Weapon", ability="weaponsmith",
                                                      primary_amount=4, level=4,
                                                      result="baseval:5")
-        self.test_recipes = (self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
-                             self.recipe6, self.recipe7)
+        self.test_recipes = [self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
+                             self.recipe6, self.recipe7]
         for recipe in self.test_recipes:
             recipe.primary_materials.add(self.mat1)
             recipe.locks.add("learn:all();teach:all()")

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -244,10 +244,11 @@ class TestEquipmentMixins(object):
         self.recipe7 = CraftingRecipe.objects.create(name="Medium Weapon", ability="weaponsmith",
                                                      primary_amount=4, level=4,
                                                      result="baseval:5")
-        self.recipes = (self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
-                        self.recipe6, self.recipe7)
-        for recipe in self.recipes:
+        self.test_recipes = (self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
+                             self.recipe6, self.recipe7)
+        for recipe in self.test_recipes:
             recipe.primary_materials.add(self.mat1)
+            recipe.locks.add("learn:all();teach:all()")
         # Top1 is a wearable object with no recipe or crafter designated
         self.top1 = create.create_object(wearable_typeclass, key="Top1", location=self.room1, home=self.room1)
         self.top1.db.quality_level = 6
@@ -322,6 +323,16 @@ class TestEquipmentMixins(object):
 
     def add_recipe_additional_costs(self, val):
         """Adds additional_cost to recipes and saves them."""
-        for recipe in self.recipes:
+        for recipe in self.test_recipes:
             recipe.additional_cost = val
+            recipe.save()
+
+    def match_recipe_locks_to_level(self):
+        """Replaces with locks appropriate to recipe difficulty."""
+        for recipe in self.test_recipes:
+            lvl = recipe.level
+            lockstr = "learn: ability(%s)" % lvl
+            if lvl < 6:
+                lockstr += ";teach: ability(%s)" % lvl + 1
+            recipe.locks.replace(lockstr)
             recipe.save()

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -125,6 +125,8 @@ class ArxCommandTest(ArxTestConfigMixin, CommandTest):
         self.instance = self.cmd_class()
 
     def call_cmd(self, args, msg, **kwargs):
+        if not self.instance:
+            self.instance = self.cmd_class()
         self.call(self.instance, args, msg, caller=self.caller, **kwargs)
 
     # noinspection PyBroadException

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -249,6 +249,7 @@ class TestEquipmentMixins(object):
         for recipe in self.test_recipes:
             recipe.primary_materials.add(self.mat1)
             recipe.locks.add("learn:all();teach:all()")
+            recipe.save()
         # Top1 is a wearable object with no recipe or crafter designated
         self.top1 = create.create_object(wearable_typeclass, key="Top1", location=self.room1, home=self.room1)
         self.top1.db.quality_level = 6

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -223,30 +223,30 @@ class TestEquipmentMixins(object):
         AssetOwner.objects.create(organization_owner=self.org)
         self.org.members.create(player=self.dompc)
         self.mat1 = CraftingMaterialType.objects.create(name="Mat1", value=100)
-        self.recipe1 = CraftingRecipe.objects.create(name="Top 1 Slot",
+        self.recipe1 = CraftingRecipe.objects.create(name="Top 1 Slot", ability="tailor",
                                                      primary_amount=5, level=5,
                                                      result="slot:chest;slot_limit:1;baseval:1;penalty:2")
-        self.recipe2 = CraftingRecipe.objects.create(name="Top 2 Slot",
+        self.recipe2 = CraftingRecipe.objects.create(name="Top 2 Slot", ability="leatherworker",
                                                      primary_amount=6, level=6,
                                                      result="slot:chest;slot_limit:2")
-        self.recipe3 = CraftingRecipe.objects.create(name="Bag",
+        self.recipe3 = CraftingRecipe.objects.create(name="Bag", ability="leatherworker",
                                                      primary_amount=5, level=5,
                                                      result="slot:bag;slot_limit:2;baseval:40")
-        self.recipe4 = CraftingRecipe.objects.create(name="Small Weapon",
+        self.recipe4 = CraftingRecipe.objects.create(name="Small Weapon", ability="weaponsmith",
                                                      primary_amount=4, level=4,
                                                      result="baseval:1;weapon_skill:small wpn")
-        self.recipe5 = CraftingRecipe.objects.create(name="Hairpins",
+        self.recipe5 = CraftingRecipe.objects.create(name="Hairpins", ability="weaponsmith",
                                                      primary_amount=4, level=4,
                                                      result="slot:hair;slot_limit:2;baseval:4;")
-        self.recipe6 = CraftingRecipe.objects.create(name="Mask",
+        self.recipe6 = CraftingRecipe.objects.create(name="Mask", ability="apothecary",
                                                      primary_amount=4, level=4,
                                                      result="slot:face;slot_limit:1;fashion_mult:6")
-        self.recipe7 = CraftingRecipe.objects.create(name="Medium Weapon",
+        self.recipe7 = CraftingRecipe.objects.create(name="Medium Weapon", ability="weaponsmith",
                                                      primary_amount=4, level=4,
                                                      result="baseval:5")
-        recipes = (self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
-                   self.recipe6, self.recipe7)
-        for recipe in recipes:
+        self.recipes = (self.recipe1, self.recipe2, self.recipe3, self.recipe4, self.recipe5,
+                        self.recipe6, self.recipe7)
+        for recipe in self.recipes:
             recipe.primary_materials.add(self.mat1)
         # Top1 is a wearable object with no recipe or crafter designated
         self.top1 = create.create_object(wearable_typeclass, key="Top1", location=self.room1, home=self.room1)
@@ -319,3 +319,9 @@ class TestEquipmentMixins(object):
         for item in worn:
             outfit.add_fashion_item(item=item)
         return outfit
+
+    def add_recipe_additional_costs(self, val):
+        """Adds additional_cost to recipes and saves them."""
+        for recipe in self.recipes:
+            recipe.additional_cost = val
+            recipe.save()

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -338,6 +338,6 @@ class TestEquipmentMixins(object):
             lvl = recipe.level
             lockstr = "learn: ability(%s)" % lvl
             if lvl < 6:
-                lockstr += ";teach: ability(%s)" % lvl + 1
+                lockstr += ";teach: ability(%s)" % (lvl + 1)
             recipe.locks.replace(lockstr)
             recipe.save()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds the /cost switch to the Recipes command. This returns a message about the cost of a recipe the user has not learned yet. There are a few trims for efficiency to other messages sent to users by this command.
#### Motivation for adding to Arx
Though the help file lists it, the /cost switch functionality actually didn't exist yet.
#### Other info (issues closed, discussion etc)
Resolves Arx in-game bug ticket #12057