### PR TITLE
Add a step in the re-roster process to clear proteges

### DIFF
--- a/server/utils/arx_utils.py
+++ b/server/utils/arx_utils.py
@@ -338,6 +338,7 @@ def post_roster_dompc_cleanup(player):
         dompc = player.Dominion
     except AttributeError:
         return
+    dompc.proteges.clear()
     dompc.patron = None
     dompc.save()
     for member in dompc.memberships.filter(rank=2):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a clear() for django to break the association between a rostered patron and any proteges they might have had.
#### Motivation for adding to Arx
While the re-rostering process cleared the relationship with a patron, it does not clear relationships with proteges. Adding this step makes the roster reset process cleaner for the next player.
#### Other info (issues closed, discussion etc)
This resolves arx in-game ticket #12206