### PR TITLE
Change iamhelping to consult actual action point cap

### DIFF
--- a/commands/commands/social.py
+++ b/commands/commands/social.py
@@ -2918,7 +2918,7 @@ class CmdIAmHelping(ArxPlayerCommand):
     Allows you to donate AP to other players (with some restrictions) to
     represent helping them out with whatever they're up to: gathering supplies
     for a crafter, acting as a menial servant/helping their servants manage
-    their affairs, discreetly having annoying npcs killed, etc. It's much more 
+    their affairs, discreetly having annoying npcs killed, etc. It's much more
     effective to assist directly with investigations, crisis actions, etc,
     using those respective commands. Rate of AP conversion is 3 to 1.
     """
@@ -2950,7 +2950,7 @@ class CmdIAmHelping(ArxPlayerCommand):
             if not self.caller.pay_action_points(val):
                 raise CommandError("You do not have enough AP.")
             targ.pay_action_points(-receive_amt)
-            self.msg("You have given %s %s AP." % (targ, receive_amt))
+            self.msg("Using %s of your AP, you have given %s %s AP." % (val, targ, receive_amt))
             msg = "%s has given you %s AP." % (self.caller, receive_amt)
             targ.inform(msg, category=msg)
         except CommandError as err:

--- a/commands/commands/social.py
+++ b/commands/commands/social.py
@@ -2915,49 +2915,46 @@ class CmdIAmHelping(ArxPlayerCommand):
         Usage:
             +iamhelping <player>=<AP>
 
-    Allows you to donate AP to other players with some restrictions to
+    Allows you to donate AP to other players (with some restrictions) to
     represent helping them out with whatever they're up to: gathering supplies
     for a crafter, acting as a menial servant/helping their servants manage
-    their affairs, discreetly having annoying npcs killed, etc. This has a
-    poor conversion rate, so it's much more effective to assist them
-    directly with investigations, crisis actions, etc, with the accustomed
-    commands.
-
-    Current rate of exchange is 3 to 1.
+    their affairs, discreetly having annoying npcs killed, etc. It's much more 
+    effective to assist directly with investigations, crisis actions, etc,
+    using those respective commands. Rate of AP conversion is 3 to 1.
     """
     key = "+iamhelping"
     help_category = "Social"
+    ap_conversion = 3
 
     def func(self):
         """Executes the +iamhelping command"""
-        if not self.args:
-            self.msg("You have %s AP remaining." % self.caller.roster.action_points)
-            return
-        targ = self.caller.search(self.lhs)
-        if not targ:
-            return
         try:
-            val = int(self.rhs)
-        except (ValueError, TypeError):
-            self.msg("AP needs to be a number.")
-            return
-        receive_amt = val/3
-        if receive_amt < 1:
-            self.msg("Must transfer at least 1 AP to them.")
-            return
-        if targ.roster.action_points + receive_amt > 100:
-            self.msg("That would put them over 100 AP.")
-            return
-        if not self.caller.pay_action_points(val):
-            self.msg("You do not have enough AP.")
-            return
-        if self.caller.roster.current_account == targ.roster.current_account:
-            self.msg("You cannot give AP to an alt.")
-            return
-        targ.pay_action_points(-receive_amt)
-        self.msg("You have given %s %s AP." % (targ, receive_amt))
-        msg = "%s has given you %s AP." % (self.caller, receive_amt)
-        targ.inform(msg, category=msg)
+            if not self.args:
+                self.msg("You have %s AP remaining." % self.caller.roster.action_points)
+                return
+            targ = self.caller.search(self.lhs)
+            if not targ:
+                return
+            try:
+                val = int(self.rhs)
+            except (ValueError, TypeError):
+                raise CommandError("AP needs to be a number.")
+            if self.caller.roster.current_account == targ.roster.current_account:
+                raise CommandError("You cannot give AP to an alt.")
+            receive_amt = val/self.ap_conversion
+            if receive_amt < 1:
+                raise CommandError("Must transfer at least %s AP." % self.ap_conversion)
+            max_ap = targ.roster.max_action_points
+            if targ.roster.action_points + receive_amt > max_ap:
+                raise CommandError("That would put them over %s AP." % max_ap)
+            if not self.caller.pay_action_points(val):
+                raise CommandError("You do not have enough AP.")
+            targ.pay_action_points(-receive_amt)
+            self.msg("You have given %s %s AP." % (targ, receive_amt))
+            msg = "%s has given you %s AP." % (self.caller, receive_amt)
+            targ.inform(msg, category=msg)
+        except CommandError as err:
+            self.msg(err)
 
 
 class CmdRPHooks(ArxPlayerCommand):

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -336,6 +336,24 @@ class SocialTests(ArxCommandTest):
             self.caller.db.watching.append(self.char2)
         self.call_cmd("testAccount2", "You may only have %s characters on your watchlist." % max_size)
 
+    def test_cmd_iamhelping(self):
+        self.setup_cmd(social.CmdIAmHelping, self.account)
+        self.account2.inform = Mock()
+        ap_cap = self.roster_entry.max_action_points
+        self.call_cmd("", "You have 0 AP remaining.")
+        self.call_cmd("Char2=30", "You do not have enough AP.")
+        self.roster_entry2.action_points = 250
+        self.roster_entry.action_points = 300
+        # TODO: test attempt to give to account1's alt
+        self.call_cmd("Char2=1", "Must transfer at least 3 AP.")
+        self.call_cmd("Char2=aipl", "AP needs to be a number.")
+        self.call_cmd("Char2=300", "That would put them over %s AP." % ap_cap)
+        self.call_cmd("Char2=90", "Using 90 of your AP, you have given Char2 30 AP.")
+        inform_msg = "Char has given you 30 AP."
+        self.account2.inform.assert_called_with(inform_msg, append=False, category=inform_msg)
+        self.assertEqual(self.roster_entry2.action_points, 280)
+        self.assertEqual(self.roster_entry.action_points, 210)
+
     def test_cmd_rphooks(self):
         self.setup_cmd(social.CmdRPHooks, self.account)
         self.call_cmd("/add bad: name", "That category name contains invalid characters.")

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -351,9 +351,9 @@ class SocialTests(ArxCommandTest):
         self.call_cmd("testaccount2=1", "Must transfer at least 3 AP.")
         self.call_cmd("testaccount2=aipl", "AP needs to be a number.")
         self.call_cmd("testaccount2=300", "That would put them over %s AP." % ap_cap)
-        inform_msg = "TestAccount has given you 30 AP."
+        inform_msg = "Testaccount has given you 30 AP."
         self.call_cmd("testaccount2=90", "You use 90 action points and have 210 remaining this week."
-                                         "|Using 90 of your AP, you have given TestAccount2 30 AP.")
+                                         "|Using 90 of your AP, you have given Testaccount2 30 AP.")
         self.account2.inform.assert_called_with(inform_msg, category=inform_msg)
         self.assertEqual(self.roster_entry2.action_points, 280)
         self.assertEqual(self.roster_entry.action_points, 210)

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -337,20 +337,23 @@ class SocialTests(ArxCommandTest):
         self.call_cmd("testAccount2", "You may only have %s characters on your watchlist." % max_size)
 
     def test_cmd_iamhelping(self):
+        from web.character.models import PlayerAccount
         self.setup_cmd(social.CmdIAmHelping, self.account)
+        paccount1 = PlayerAccount.objects.create(email="foo@foo.com")
         self.account2.inform = Mock()
         ap_cap = self.roster_entry.max_action_points
         self.call_cmd("", "You have 100 AP remaining.")
+        self.call_cmd("testaccount2=30", "You cannot give AP to an alt.")
+        self.caller.roster.current_account = paccount1
         self.call_cmd("testaccount2=102", "You do not have enough AP.")
         self.roster_entry2.action_points = 250
         self.roster_entry.action_points = 300
-        # TODO: test attempt to give to account1's alt
         self.call_cmd("testaccount2=1", "Must transfer at least 3 AP.")
         self.call_cmd("testaccount2=aipl", "AP needs to be a number.")
         self.call_cmd("testaccount2=300", "That would put them over %s AP." % ap_cap)
-        self.call_cmd("testaccount2=90", "Using 90 of your AP, you have given TestAccount2 30 AP.")
         inform_msg = "TestAccount has given you 30 AP."
-        self.account2.inform.assert_called_with(inform_msg, append=False, category=inform_msg)
+        self.call_cmd("testaccount2=90", "Using 90 of your AP, you have given TestAccount2 30 AP.")
+        self.account2.inform.assert_called_with(inform_msg, category=inform_msg)
         self.assertEqual(self.roster_entry2.action_points, 280)
         self.assertEqual(self.roster_entry.action_points, 210)
 

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -340,8 +340,8 @@ class SocialTests(ArxCommandTest):
         self.setup_cmd(social.CmdIAmHelping, self.account)
         self.account2.inform = Mock()
         ap_cap = self.roster_entry.max_action_points
-        self.call_cmd("", "You have 0 AP remaining.")
-        self.call_cmd("Char2=30", "You do not have enough AP.")
+        self.call_cmd("", "You have 100 AP remaining.")
+        self.call_cmd("Char2=102", "You do not have enough AP.")
         self.roster_entry2.action_points = 250
         self.roster_entry.action_points = 300
         # TODO: test attempt to give to account1's alt

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -341,15 +341,15 @@ class SocialTests(ArxCommandTest):
         self.account2.inform = Mock()
         ap_cap = self.roster_entry.max_action_points
         self.call_cmd("", "You have 100 AP remaining.")
-        self.call_cmd("Char2=102", "You do not have enough AP.")
+        self.call_cmd("testaccount2=102", "You do not have enough AP.")
         self.roster_entry2.action_points = 250
         self.roster_entry.action_points = 300
         # TODO: test attempt to give to account1's alt
-        self.call_cmd("Char2=1", "Must transfer at least 3 AP.")
-        self.call_cmd("Char2=aipl", "AP needs to be a number.")
-        self.call_cmd("Char2=300", "That would put them over %s AP." % ap_cap)
-        self.call_cmd("Char2=90", "Using 90 of your AP, you have given Char2 30 AP.")
-        inform_msg = "Char has given you 30 AP."
+        self.call_cmd("testaccount2=1", "Must transfer at least 3 AP.")
+        self.call_cmd("testaccount2=aipl", "AP needs to be a number.")
+        self.call_cmd("testaccount2=300", "That would put them over %s AP." % ap_cap)
+        self.call_cmd("testaccount2=90", "Using 90 of your AP, you have given TestAccount2 30 AP.")
+        inform_msg = "TestAccount has given you 30 AP."
         self.account2.inform.assert_called_with(inform_msg, append=False, category=inform_msg)
         self.assertEqual(self.roster_entry2.action_points, 280)
         self.assertEqual(self.roster_entry.action_points, 210)

--- a/commands/commands/tests.py
+++ b/commands/commands/tests.py
@@ -352,7 +352,8 @@ class SocialTests(ArxCommandTest):
         self.call_cmd("testaccount2=aipl", "AP needs to be a number.")
         self.call_cmd("testaccount2=300", "That would put them over %s AP." % ap_cap)
         inform_msg = "TestAccount has given you 30 AP."
-        self.call_cmd("testaccount2=90", "Using 90 of your AP, you have given TestAccount2 30 AP.")
+        self.call_cmd("testaccount2=90", "You use 90 action points and have 210 remaining this week."
+                                         "|Using 90 of your AP, you have given TestAccount2 30 AP.")
         self.account2.inform.assert_called_with(inform_msg, category=inform_msg)
         self.assertEqual(self.roster_entry2.action_points, 280)
         self.assertEqual(self.roster_entry.action_points, 210)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The sum of the target's current action points and caller's proposed donation is compared to max_action_points property (as defined in RosterEntry,) instead of an arbitrary number.
#### Motivation for adding to Arx
Allows more flexibility for the AP cap to be adjusted without considering its impact on other commands.
#### Other info (issues closed, discussion etc)
This also resolves Arx in-game ticket #12060