### PR TITLE
This commit does the following:

### DIFF
--- a/commands/cmdsets/situational.py
+++ b/commands/cmdsets/situational.py
@@ -28,3 +28,4 @@ class SituationalCmdSet(CmdSet):
         self.add(readable.WriteCmdSet())
         self.add(readable.SignCmdSet())
         self.add(container.CmdChestKey())
+

--- a/commands/cmdsets/standard.py
+++ b/commands/cmdsets/standard.py
@@ -127,7 +127,13 @@ try:
 except Exception as err:
     traceback.print_exc()
     print("<<ERROR>>: Error encountered in petition commands: %s" % err)
+try:
+    from typeclasses.containers.container import CmdRoot
+except Exception as err:
+    print("<<ERROR>>: Error encountered in container commands: %s" % err)
+
 from evennia.commands.cmdset import CmdSet
+
 
 
 class OOCCmdSet(CmdSet):
@@ -326,3 +332,4 @@ class StaffCmdSet(CmdSet):
         self.add(home.CmdAllowBuilding())
         self.add(home.CmdBuildRoom())
         self.add(home.CmdManageRoom())
+        self.add(CmdRoot())

--- a/commands/commands/crafting.py
+++ b/commands/commands/crafting.py
@@ -86,6 +86,8 @@ def create_container(recipe, roll, proj, caller):
     quality = get_quality_lvl(roll, recipe.difficulty)
     obj = create_obj(CONTAINER, proj[1], caller, caller, quality)
     obj.db.max_volume = base + int(scaling * quality)
+    if recipe.resultsdict.get("displayable") == "true":
+       obj.tags.add("displayable")
     try:
         obj.grantkey(caller)
     except (TypeError, AttributeError, ValueError):

--- a/typeclasses/mixins.py
+++ b/typeclasses/mixins.py
@@ -921,7 +921,7 @@ class LockMixins(object):
         :return: str
         """
         currently_open = not self.db.locked
-        show_contents = currently_open and show_contents
+        show_contents = (currently_open or self.tags.get("displayable")) and show_contents
         base = super(LockMixins, self).return_appearance(pobject, detailed=detailed,
                                                          format_desc=format_desc, show_contents=show_contents)
         return base + "\nIt is currently %s." % ("locked" if self.db.locked else "unlocked")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

* Add the concept of the "displayable" idict property for containers. This allows
the contents of containers to be observed whether or not they are locked.

* Adds a 'root' and 'unroot' command that can only be targeted at container (and
not wearable container) objects. If a user is a decorator, it modifies the 'get'
lock to restrict access to accounts with the Builder perm, or characters with
decorator access on the room.

#### Motivation for adding to Arx

* Provides the ability to allow objects to be shown off (trophy cases, etc), without making them easy to steal. 

* Also, allows for the rooting of containers, like chests, etc.

#### Other info (issues closed, discussion etc)