### PR TITLE
Filter lore subcategories out of main lore list

### DIFF
--- a/web/help_topics/templates/help_topics/list.html
+++ b/web/help_topics/templates/help_topics/list.html
@@ -40,29 +40,6 @@
 				</a>
 			</figure>
 		</div>
-	<hr/>
-
-	<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %} text-center">
-	<button data-toggle="collapse" data-target="#Topics"><h1 class="bg-primary">Gameplay Topics</h1></button>
-	</div> <!--button-->
-	<div id="Topics" class="collapse in">
-    {% for category in all_categories %}
-	<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">
-      <h2 class="text-center">{{ category }}</h2>
-	  <ul class="list-inline text-center">
-      {% for topic in all_topics %}
-        {% if topic.help_category.capitalize == category %}         
-          <li class="text-center"><a href="{% url 'help_topics:topic' topic.key %}">{{ topic.key }}</a></li>
-        {% endif %}
-      {% empty %}
-        <li>No topics found for this category.</li>
-      {% endfor %}
-	  </ul>
-	</div><!-- div in for loop -->
-    {% empty %}
-      <div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">No categories found.</div>
-    {% endfor %}
-	</div><!-- collapse-in -->
 
 	<hr/>
 
@@ -72,8 +49,8 @@
 	<div id="Lore" class="collapse in">
 		<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">
 		<ul class="list-inline text-center">
-		{% for cat in lore_categories %}
-			<li><a href="{% url 'help_topics:lore' cat.id %}">{{ cat }}</a></li>
+		{% for lore_cat in lore_categories %}
+			<li class="list-inline-item"><a href="{% url 'help_topics:lore' lore_cat.id %}">{{ lore_cat }}</a></li>
 			{% empty %}
 			<li>No lore found.</li>
 		{% endfor %}
@@ -90,22 +67,46 @@
 		<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">
 		<ul class="list-inline text-center">
 		{% for org in all_orgs %}
-			<li><a href="..{% url 'help_topics:display_org' org.id %}">{{ org.name }}</a></li>
+			<li class="list-inline-item"><a href="..{% url 'help_topics:display_org' org.id %}">{{ org.name }}</a></li>
 		  {% empty %}
 			<li>No organizations found.</li>
 		{% endfor %}
 		</ul>
 		</div>
 	{% if secret_orgs %}
-		<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">
+		<div class="row {% cycle 'bg-info' 'bg-success' as rowcolors %}">
 		<h2 class="text-center">Secret Organizations</h2>
 		<ul class="list-inline text-center">
 		{% for org in secret_orgs %}
-			<li><a href="..{% url 'help_topics:display_org' org.id %}">{{ org.name }}</a></li>
+			<li class="list-inline-item"><a href="..{% url 'help_topics:display_org' org.id %}">{{ org.name }}</a></li>
 		{% endfor %}
 		</ul>
 		</div>
 	{% endif %}
+	</div><!-- collapse-in -->
+
+	<hr/>
+
+	<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %} text-center">
+	<button data-toggle="collapse" data-target="#Topics"><h1 class="bg-primary">Gameplay Topics</h1></button>
+	</div> <!--button-->
+	<div id="Topics" class="collapse in">
+    {% for category in all_categories %}
+	<div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}"">
+      <h2 class="text-center">{{ category }}</h2>
+	  <ul class="list-inline text-center">
+      {% for topic in all_topics %}
+        {% if topic.help_category.capitalize == category %}
+          <li class="text-center"><a href="{% url 'help_topics:topic' topic.key %}">{{ topic.key }}</a></li>
+        {% endif %}
+      {% empty %}
+        <li>No topics found for this category.</li>
+      {% endfor %}
+	  </ul>
+	</div><!-- div in for loop -->
+    {% empty %}
+      <div class="row {% cycle 'bg-success' 'bg-info' as rowcolors %}">No categories found.</div>
+    {% endfor %}
 	</div><!-- collapse-in -->
 
 	<hr/>

--- a/web/help_topics/templates/help_topics/lore_category.html
+++ b/web/help_topics/templates/help_topics/lore_category.html
@@ -2,17 +2,33 @@
 {% load app_filters %}
 {% block content %}
 <div class="container">
-    <h1>{{ kb_cat.title }}</h1>
-    {% if kb_cat.description %}
+    {% if kb_parent %}
+    <a href="{% url 'help_topics:lore' kb_parent.id %}">&laquo;&nbsp;Back to {{ kb_parent.title|mush_to_html }}</a>
+    {% else %}
+    <a href="{% url 'help_topics:list_topics' %}#Lore">&laquo;&nbsp;Back to Lore Topics</a>
+    {% endif %}
+
+    <h1 class="text-center">{{ kb_cat.title }}</h1>
+    {% if kb_cat.description or kb_subs %}
     <div class="well">
-        {{ kb_cat.description|mush_to_html }}
+        {% if kb_subs %}
+        <strong>Subcategories:</strong>&nbsp;
+        <ul class="list-inline">
+		{% for subcat in kb_subs %}
+			<li class="list-inline-item"><a href="{% url 'help_topics:lore' subcat.id %}">{{ subcat }}</a></li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+        <p>{{ kb_cat.description|mush_to_html }}</p>
     </div>
     {% endif %}
 
     <h2>Entries</h2>
     {% for entry in kb_items %}
     <div class="dividingBorderAbove">
-        <p class="newsHeading">{{ entry.title|mush_to_html }}</p>
+        <p id="{{ entry.title|mush_to_html }}">
+            <a href="#{{ entry.title|mush_to_html }}" class="newsHeading">{{ entry.title|mush_to_html }}</a>
+        </p>
         {% if entry.question %}
         <p class="newsSummary"><strong>Question:</strong> {{ entry.question|mush_to_html }}</p>
         {% endif %}

--- a/web/help_topics/views.py
+++ b/web/help_topics/views.py
@@ -63,7 +63,7 @@ def list_topics(request):
                                                       & Q(members__player__player=user))
     except Exception:
         pass
-    lore_categories = KBCategory.objects.all()
+    lore_categories = KBCategory.objects.filter(parent__isnull=True)
     return render(request, 'help_topics/list.html', {'all_topics': all_topics,
                                                      'all_categories': all_categories,
                                                      'lore_categories': lore_categories,
@@ -183,4 +183,6 @@ def lore_categories(request, object_id):
     kb_cat = get_object_or_404(KBCategory, id=object_id)
     return render(request, 'help_topics/lore_category.html', {'kb_cat': kb_cat,
                                                               'kb_items': kb_cat.kb_items.all(),
+                                                              'kb_subs': kb_cat.subcategories.all(),
+                                                              'kb_parent': kb_cat.parent,
                                                               'page_title': kb_cat})


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves lore subcategories from the main list into their parent's page. Adds some anchor tags. Also shifts the lore section above the huge gameplay topics for accessibility.
#### Motivation for adding to Arx
More presentation in baby steps.
#### Other info (issues closed, discussion etc)
We're getting there!