### PR TITLE
Display tags for clues on web

### DIFF
--- a/web/character/templates/character/clue_list.html
+++ b/web/character/templates/character/clue_list.html
@@ -17,6 +17,10 @@
             <td valign="top">{{ clue.clue.id }}</td>
 			<td valign="top"><b>{{ clue.clue.name }}</b></td>
             <td valign="top">{{ clue.clue.desc|mush_to_html }}
+            {% if clue.clue.keywords %}
+                <br/>&nbsp;<br/>
+                {{ clue.clue.keywords|join:", " }}
+            {% endif %}
 			{% if clue.message %}
 				<br/>&nbsp;<br/>
 				{{ clue.message|mush_to_html }}

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -264,6 +264,18 @@ class ViewTests(ArxTest):
         response = self.client.get(reverse('character:list_flashbacks', kwargs={'object_id': self.char2.id}))
         self.assertEqual(response.status_code, 200)
 
+    def test_view_tagged_clues(self):
+        """tags are rendered with clues"""
+        tag1 = SearchTag.objects.create(name="foo")
+        tag2 = SearchTag.objects.create(name="bar")
+        tag3 = SearchTag.objects.create(name="zep")
+        clue = Clue.objects.create(name="test clue", rating=10, desc="test clue desc")
+        clue.search_tags.add(tag1, tag2, tag3)
+        self.roster_entry2.clue_discoveries.create(clue=clue, message="additional text test")
+        self.assertEqual(self.client.login(username='TestAccount2', password='testpassword'), True)
+        response = self.client.get(reverse('character:list_clues', kwargs={'object_id': self.char2.id}))
+        self.assertContains(response, "foo, bar, zep")
+
 
 class PRPClueTests(ArxCommandTest):
     def setUp(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This adds clue tags to the website.

#### Motivation for adding to Arx

I want to be able to see tags on the website when browsing clues.

#### Other info (issues closed, discussion etc)

I've unittested this, but I am having trouble standing up a local game to test this in a local environment.