### PR TITLE
Do not display clue table for missing clues #164

### DIFF
--- a/web/character/investigation.py
+++ b/web/character/investigation.py
@@ -1382,8 +1382,7 @@ class CmdListClues(ArxPlayerCommand):
                     except Clue.DoesNotExist:
                         pass
                 if not discovery:
-                    self.msg("No clue found by that ID.")
-                    self.disp_clue_table()
+                    self.msg("No clue found by this ID: {w%s{n." % self.lhs)
                     return
             if not self.switches:
                 self.msg(discovery.display(show_gm_notes=self.called_by_staff))

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -64,6 +64,7 @@ class InvestigationTests(ArxCommandTest):
         self.caller = self.account2
         self.call_cmd("2", ("[test clue2] (50 Rating)\ntest clue2 desc\n{} This clue was shared with you by Char,"
                             " who noted: {}\n").format(now.strftime("%x %X"), "Love Tehom"*8))
+        self.call_cmd("222", ("No clue found by this ID: 222."))
 
     def test_cmd_helpinvestigate(self):
         self.roster_entry2.investigations.create()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This removes the table display when the clue <id> command is called by a user who does not have the corresponding clue.

#### Motivation for adding to Arx

I agree with the request in #164. That's been bugging me too.
