### PR TITLE
Add title and theory number to informs for #144

### DIFF
--- a/web/character/investigation.py
+++ b/web/character/investigation.py
@@ -1658,7 +1658,8 @@ class CmdTheories(ArxPlayerCommand):
                     continue
                 theory.share_with(targ)
                 self.msg("Theory %s added to %s." % (self.lhs, targ))
-                targ.inform("%s has shared a theory with you." % self.caller, category="Theories")
+                targ.inform("%s has shared theory {w'%s'{n with you. Use {w@theories %s{n to view it." % (
+                    self.caller, theory.topic, self.lhs), category="Theories")
             return
         if "delete" in self.switches or "forget" in self.switches:
             try:

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -82,6 +82,15 @@ class InvestigationTests(ArxCommandTest):
             fake_method.return_value = True
             self.call_cmd("/finish", "Char is now helping Char2's investigation on .")
 
+    def test_cmd_theories(self):
+        self.account2.inform = Mock()
+        self.setup_cmd(investigation.CmdTheories, self.account)
+        self.call_cmd("/create gravity=Things fall.", "You have created a new theory.")
+        self.call_cmd("/share 1=TestAccount2", "Theory 1 added to Testaccount2.")
+        self.account2.inform.assert_called_with(
+            "Testaccount has shared theory {w'gravity'{n with you. Use {w@theories 1{n to view it.",
+            category='Theories')
+
     def test_cmd_investigate(self):
         tag1 = SearchTag.objects.create(name="foo")
         tag2 = SearchTag.objects.create(name="bar")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This adds the theory title and number to the inform when someone shares a theory.

#### Motivation for adding to Arx

#144 is a papercut for me too and the change to add it is pretty small. I figured, why not.

#### Other info (issues closed, discussion etc)

Maybe the description could also be included in the inform, but I didn't do it for this change.

This isn't ready to merge yet. There are no unit tests for theories that I could find, and I'd like to make at least one. I also haven't smoke tested this in a live environment. I'm having trouble populating my local db with characters.