### PR TITLE
Fix Flashback uninvite bug

### DIFF
--- a/web/character/admin.py
+++ b/web/character/admin.py
@@ -4,7 +4,7 @@ Admin models for Character app
 from django.contrib import admin
 from django.forms import ModelForm
 from .models import (Roster, RosterEntry, Photo, SearchTag, FlashbackPost, Flashback,
-                     Story, Chapter, Episode, StoryEmit,
+                     FlashbackInvolvement, Story, Chapter, Episode, StoryEmit,
                      Milestone, FirstContact, CluePlotInvolvement, RevelationPlotInvolvement,
                      PlayerAccount, AccountHistory, InvestigationAssistant,
                      Mystery, Revelation, Clue, Investigation,
@@ -410,17 +410,23 @@ class PostInline(admin.StackedInline):
     extra = 0
     exclude = ('readable_by', 'db_date_created')
     raw_id_fields = ('poster',)
-    fieldsets = [(None, {'fields': ['poster']}),
-                 ('Story', {'fields': ['actions'], 'classes': ['collapse']}),
-                 ]
+    fieldsets = [(None, {'fields': ['poster', 'actions'], 'classes': ['collapse']})]
+
+
+class FBParticipantsInline(admin.StackedInline):
+    """Inline for Flashback Participants"""
+    model = FlashbackInvolvement
+    extra = 0
+    readonly_fields = ('roll',)
+    raw_id_fields = ('participant',)
 
 
 class FlashbackAdmin(BaseCharAdmin):
     """Admin for Flashbacks"""
     list_display = ('id', 'title', 'owner',)
     search_fields = ('id', 'title', 'participants__player__username')
-    inlines = [PostInline]
-    fieldsets = [(None, {'fields': [('title'), 'summary']})]
+    inlines = [PostInline, FBParticipantsInline]
+    fieldsets = [(None, {'fields': ['title', 'summary']})]
 
     @staticmethod
     def owner(obj):

--- a/web/character/models.py
+++ b/web/character/models.py
@@ -1873,7 +1873,7 @@ class Flashback(SharedMemoryModel):
         else:
             posts = self.posts.all()
             inv.participant.flashback_post_permissions.filter(post__in=posts).delete()
-            del inv
+            inv.delete()
 
     def invite_roster(self, roster_entry, retro=False, owner=False):
         """Creates or unretires a FlashbackInvolvement."""

--- a/web/character/scene_commands.py
+++ b/web/character/scene_commands.py
@@ -174,7 +174,7 @@ class CmdFlashback(RewardRPToolUseMixin, ArxPlayerCommand):
         retro = "retro" in self.switches
         retro_msg = " with all previous posts visible" if retro else ""
         flashback.invite_roster(target.roster, retro=retro)
-        self.msg("You have invited %s to participate in this flashback%s." % (target, retro_msg))
+        self.msg("You have invited %s to participate in flashback #%s%s." % (target, flashback.id, retro_msg))
 
     def uninvite_target(self, flashback, target, inv=None):
         """Calls method to change contributor to 'retired', or delete non-contributor involvement."""
@@ -186,7 +186,7 @@ class CmdFlashback(RewardRPToolUseMixin, ArxPlayerCommand):
         elif target != self.caller and self.roster_entry not in owners:
             return self.msg("Only the flashback's owner can uninvite other players.")
         flashback.uninvite_involvement(inv)
-        self.msg("You have uninvited %s from this flashback." % target)
+        self.msg("You have uninvited %s from flashback #%s." % (target, flashback.id))
         if target != self.caller:
             target.inform("You have been retired from flashback #%s." % flashback.id,
                           category="Flashbacks")

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -203,8 +203,8 @@ class SceneCommandTests(ArxCommandTest):
         self.assertEqual(self.char1.messages.num_flashbacks, 1)
         self.account.inform = Mock()
         self.account2.inform = Mock()
-        self.call_cmd("/invite/retro 1=Testaccount2", "You have invited Testaccount2 to participate in this "
-                                                      "flashback with all previous posts visible.")
+        self.call_cmd("/invite/retro 1=Testaccount2", "You have invited Testaccount2 to participate in "
+                                                      "flashback #1 with all previous posts visible.")
         self.account2.inform.assert_called_with("You have been invited to participate in flashback #1:"
                                                 " 'testing'.", category="Flashbacks")
         mock_build_msg.return_value = "Galvanion checked willpower at difficulty 9001, rolling 9000 lower."
@@ -228,9 +228,13 @@ class SceneCommandTests(ArxCommandTest):
         self.call_cmd("/summary 1=test", "Only the flashback's owner may use that switch.")
         self.call_cmd("/invite 1=Testaccount", "Only the flashback's owner may use that switch.")
         self.call_cmd("/conclude 1", "Only the flashback's owner may use that switch.")
+        self.call_cmd("/uninvite 1", "You have uninvited Testaccount2 from flashback #1.")
+        self.assertEqual(list(fb1.participants.all()), [self.roster_entry])
         self.caller = self.account
-        self.call_cmd("/invite 1", "(#1) testing - Owners and post authors: Testaccount\nCharacters invited to post: Testaccount, Testaccount2")
-        self.call_cmd("/uninvite 1=Testaccount2", "You have uninvited Testaccount2 from this flashback.")
+        self.call_cmd("/invite 1=Testaccount2", "You have invited Testaccount2 to participate in flashback #1.")
+        self.call_cmd("/invite 1",
+                      "(#1) testing - Owners and post authors: Testaccount\nCharacters invited to post: Testaccount, Testaccount2")
+        self.call_cmd("/uninvite 1=Testaccount2", "You have uninvited Testaccount2 from flashback #1.")
         self.account2.inform.assert_called_with("You have been retired from flashback #1.", category="Flashbacks")
         self.call_cmd("/summary 1=test summary", "Summary set to: test summary.")
         fb1.posts.create(poster=self.roster_entry, actions="Foo.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When uninviting from a Flashback, their FlashbackInvolvement object should either change to 'retired' status, or be deleted if no posts were made. Delete wasn't working; this fixes it. Also adds an admin tool for managing flashback participants.

#### Motivation for adding to Arx
Fixes a bug.

#### Other info (issues closed, discussion etc)
Addresses bug ticket #17169
