### PR TITLE
Use event display method rather than form in bbpost

### DIFF
--- a/commands/base_commands/social.py
+++ b/commands/base_commands/social.py
@@ -1364,8 +1364,7 @@ class CmdCalendar(ArxPlayerCommand):
 
     def do_display_switches(self):
         """Displays our project if we have one"""
-        proj = self.caller.ndb.event_creation
-        if not self.args and not self.switches and proj:
+        if not self.args and not self.switches:
             self.display_project()
             return
         if self.caller.check_permstring("builders"):
@@ -1581,12 +1580,10 @@ class CmdCalendar(ArxPlayerCommand):
     def display_project(self):
         """Sends a string display of a project"""
         form = self.form
-        msg = "{wEvent you're creating:{n\n"
-        if not form:
-            msg += "None currently."
-            return
+        if form:
+            msg = "|wEvent you're creating:|n\n" + form.display()
         else:
-            msg += form.display()
+            msg = "|wYou are not currently creating an event.|n"
         self.msg(msg, options={'box': True})
 
     def set_form_or_event_attribute(self, param, value, event=None):
@@ -1723,7 +1720,7 @@ class CmdCalendar(ArxPlayerCommand):
         else:
             raise self.CalCmdError("Private must be set to either 'on' or 'off'.")
         self.set_form_or_event_attribute("public_event", public, event)
-        self.msg("Public is now set to: %s" % public)
+        self.msg("Event set to: %s" % ("public" if public else "private"))
 
     def add_or_remove_host(self, event):
         """Adds a host or changes them to a regular guest"""
@@ -1760,10 +1757,10 @@ class CmdCalendar(ArxPlayerCommand):
             gm = self.caller.search(self.lhs).Dominion
         except AttributeError:
             return
-        add_msg = "%s is now marked as a gm.\n"
-        add_msg += "Reminder - please only add a GM for an event if it's an actual player-run plot. Tagging a "
-        add_msg += "social event as a PRP is strictly prohibited. If you tagged this as a PRP in error, use "
-        add_msg += "gm on them again to remove them."
+        add_msg = ("|w%s is now marked as a gm.|n\n"
+                   "Reminder: Please only add a GM for an event if it's a player-run plot. Tagging a "
+                   "social event as a PRP is strictly prohibited. If you tagged this as a PRP in error, use "
+                   "gm on them again to remove them.")
         if event:
             if gm in event.gms:
                 event.untag_gm(gm)

--- a/world/dominion/forms.py
+++ b/world/dominion/forms.py
@@ -152,10 +152,10 @@ class RPEventCreateForm(forms.ModelForm):
         from evennia.scripts.models import ScriptDB
         if event.public_event:
             event_manager = ScriptDB.objects.get(db_key="Event Manager")
-            event_manager.post_event(event, self.owner.player, self.display())
+            event_manager.post_event(event, self.owner.player, event.display())
 
     def display(self):
-        """Returns a game-friend display string"""
+        """Returns a game-friendly display string"""
         msg = "{wName:{n %s\n" % self.data.get('name')
         plot = self.data.get('plot')
         if plot:

--- a/world/dominion/models.py
+++ b/world/dominion/models.py
@@ -3426,8 +3426,9 @@ class RPEvent(SharedMemoryModel):
         msg += "{wHosts:{n %s\n" % ", ".join(str(ob) for ob in self.hosts.all())
         if self.beat:
             msg += "{wPlot:{n %s\n" % self.beat.plot
-        if self.gms.all():
-            msg += "{wGMs:{n %s\n" % ", ".join(str(ob) for ob in self.gms.all())
+        gms = self.gms.all()
+        if gms:
+            msg += "{wGMs:{n %s\n" % ", ".join(str(ob) for ob in gms)
         if not self.finished and not self.public_event:
             # prevent seeing names of invites once a private event has started
             if self.date > datetime.now():
@@ -3438,6 +3439,8 @@ class RPEvent(SharedMemoryModel):
         msg += "{wLocation:{n %s\n" % self.location_name
         if not self.public_event:
             msg += "{wPrivate:{n Yes\n"
+        if gms:
+            msg += "|wRisk:|n %s\n" % self.get_risk_display()
         msg += "{wEvent Scale:{n %s\n" % self.get_celebration_tier_display()
         msg += "{wDate:{n %s\n" % self.date.strftime("%x %H:%M")
         msg += "{wDesc:{n\n%s\n" % self.desc


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Since the event is submitted, its display can be used when announcing to bboards, rather than the UNCLEAN data in the form's display method.
#### Motivation for adding to Arx
Avoids adding ghost hosts/guests to event announcements.
#### Other info (issues closed, discussion etc)
Added some unit tests and fixed a spot of unreachable code when checking nonexistent event project. Fixes #155 