### PR TITLE
Add server config for cost of writing new clues

### DIFF
--- a/commands/base_commands/staff_commands.py
+++ b/commands/base_commands/staff_commands.py
@@ -1800,8 +1800,9 @@ class CmdSetServerConfig(ArxPlayerCommand):
     shorthand_to_real_keys = {"motd": "MESSAGE_OF_THE_DAY",
                               "income": "GLOBAL_INCOME_MOD",
                               "ap transfers disabled": "DISABLE_AP_TRANSFER",
-                              "cg bonus skill points": "CHARGEN_BONUS_SKILL_POINTS"}
-    valid_keys = shorthand_to_real_keys.keys()
+                              "cg bonus skill points": "CHARGEN_BONUS_SKILL_POINTS",
+                              "new clue ap cost": "NEW_CLUE_AP_COST"}
+    valid_keys = sorted(shorthand_to_real_keys.keys())
 
     def get_help(self, caller, cmdset):
         """Modifies help string"""
@@ -1857,9 +1858,9 @@ class CmdSetServerConfig(ArxPlayerCommand):
                     broadcast("|yServer Message of the Day:|n %s" % val)
                 elif key == "ap transfers disabled":
                     val = bool(self.rhs)
-                elif key == "cg bonus skill points":
+                elif key in ("cg bonus skill points", "new clue ap cost"):
                     if not val.isdigit():
-                        return self.msg("Chargen bonus skill points must be a number.")
+                        return self.msg("This must be a number.")
                     val = int(val)
                 ServerConfig.objects.conf(key=real_key, value=val)
             self.list_config_values()

--- a/commands/base_commands/tests.py
+++ b/commands/base_commands/tests.py
@@ -968,20 +968,23 @@ class StaffCommandTests(ArxCommandTest):
 
     def test_cmd_config(self):
         self.setup_cmd(staff_commands.CmdSetServerConfig, self.account)
-        self.call_cmd("asdf", 'Not a valid key: cg bonus skill points, ap transfers disabled, motd, income')
-        self.call_cmd("income=5", '| key                                    | value                             '
-                                  '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+\n'
-                                  '| cg bonus skill points                  | None                              '
-                                  '| ap transfers disabled                  | None                              '
-                                  '| motd                                   | None                              '
-                                  '| income                                 | 5.0')
+        self.call_cmd("asdf", 'Not a valid key: ap transfers disabled, cg bonus skill points, income, motd, new clue ap cost')
+        self.call_cmd("income=5",
+                      '| key                                    | value                             '
+                      '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+\n'                      
+                      '| ap transfers disabled                  | None                              '
+                      '| cg bonus skill points                  | None                              '
+                      '| income                                 | 5.0                               '                      
+                      '| motd                                   | None                              '
+                      '| new clue ap cost                       | None')
         self.call_cmd("cg bonus skill points=20",
                       '| key                                    | value                             '
                       '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+\n'
-                      '| cg bonus skill points                  | 20                                '
                       '| ap transfers disabled                  | None                              '
+                      '| cg bonus skill points                  | 20                                '
+                      '| income                                 | 5.0                               '                      
                       '| motd                                   | None                              '
-                      '| income                                 | 5.0')
+                      '| new clue ap cost                       | None')
 
     def test_cmd_adjustfame(self):
         self.setup_cmd(staff_commands.CmdAdjustFame, self.account)

--- a/web/character/admin.py
+++ b/web/character/admin.py
@@ -194,6 +194,27 @@ class CluePlotInvolvementInline(admin.TabularInline):
     classes = ['collapse']
 
 
+class ClueListTagFilter(admin.SimpleListFilter):
+    """List filter for clues with or without search tags"""
+    title = "Search Tags"
+    parameter_name = "search tags"
+
+    def lookups(self, request, model_admin):
+        """Values for the GET request and how they display"""
+        return (
+            ('have_tags', 'Have Tags'),
+            ('no_tags', "No Tags")
+        )
+
+    def queryset(self, request, queryset):
+        """Modifies the queryset of Clues to filter those with, or without, search_tags"""
+        qs = queryset
+        if self.value() == 'have_tags':
+            return qs.filter(search_tags__isnull=False)
+        elif self.value() == 'no_tags':
+            return qs.filter(search_tags__isnull=True)
+
+
 class ClueAdmin(BaseCharAdmin):
     """Admin for Clues"""
     list_display = ('id', 'name', 'rating', 'used_for')
@@ -201,7 +222,7 @@ class ClueAdmin(BaseCharAdmin):
     inlines = (ClueForRevInline, CluePlotInvolvementInline)
     filter_horizontal = ('search_tags',)
     raw_id_fields = ('author', 'tangible_object',)
-    list_filter = ('clue_type', 'allow_investigation')
+    list_filter = ('clue_type', 'allow_investigation', ClueListTagFilter)
     readonly_fields = ('discovered_by',)
 
     def used_for(self, obj):

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -7,6 +7,7 @@ from django.test import Client
 from django.urls import reverse
 
 from server.utils.test_utils import ArxCommandTest, ArxTest
+from evennia.server.models import ServerConfig
 from web.character import investigation, scene_commands, goal_commands
 from web.character.models import Clue, Revelation, SearchTag, Goal
 
@@ -14,6 +15,7 @@ from web.character.models import Clue, Revelation, SearchTag, Goal
 class InvestigationTests(ArxCommandTest):
     def setUp(self):
         super(InvestigationTests, self).setUp()
+        ServerConfig.objects.conf(key='NEW_CLUE_AP_COST', value=100)
         self.clue = Clue.objects.create(name="test clue", rating=10, desc="test clue desc")
         self.clue2 = Clue.objects.create(name="test clue2", rating=50, desc="test clue2 desc")
         self.revelation = Revelation.objects.create(name="test revelation", desc="test rev desc",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Allows admin to set the action point cost of writing a new clue for an investigation. Also adds a filter in django admin to list the Clues that are missing search tags. Adds unit tests.

#### Motivation for adding to Arx
Replaces a hard-coded action point price. Lets admin easily see which clues are not currently able to be investigated due to lack of search tags.
