### PR TITLE
Cal plotroom/location toggle

### DIFF
--- a/commands/base_commands/social.py
+++ b/commands/base_commands/social.py
@@ -1662,6 +1662,16 @@ class CmdCalendar(ArxPlayerCommand):
         if event:
             self.caller.char_ob.pay_money(cost)
 
+    def set_event_desc(self, event):
+        """Sets description of an event"""
+        self.set_form_or_event_attribute("desc", self.lhs, event)
+        self.msg("Desc of event set to:\n%s" % self.lhs)
+
+    def set_room_desc(self, event):
+        """Sets description appended to event's location"""
+        self.set_form_or_event_attribute("room_desc", self.lhs, event)
+        self.msg("Room desc of event set to:\n%s" % self.lhs)
+
     def set_location(self, event=None):
         """Sets location for form or an event"""
         if self.lhs and self.lhs.lower() != "here":
@@ -1679,18 +1689,9 @@ class CmdCalendar(ArxPlayerCommand):
         if not room:
             raise self.CalCmdError("No room found.")
         id_or_instance = room if event else room.id
+        self.set_form_or_event_attribute("plotroom", None, event)
         self.set_form_or_event_attribute("location", id_or_instance, event)
         self.msg("Room set to %s." % room)
-
-    def set_event_desc(self, event):
-        """Sets description of an event"""
-        self.set_form_or_event_attribute("desc", self.lhs, event)
-        self.msg("Desc of event set to:\n%s" % self.lhs)
-
-    def set_room_desc(self, event):
-        """Sets description appended to event's location"""
-        self.set_form_or_event_attribute("room_desc", self.lhs, event)
-        self.msg("Room desc of event set to:\n%s" % self.lhs)
 
     def set_plotroom(self, event):
         """Sets the virtual 'plotroom' for an event, if any."""
@@ -1714,10 +1715,11 @@ class CmdCalendar(ArxPlayerCommand):
                 raise self.CalCmdError(msg)
             plotroom = plotrooms[0]
             id_or_instance = plotroom if event else plotroom.id
+            self.set_form_or_event_attribute("location", None, event)
             self.set_form_or_event_attribute("plotroom", id_or_instance, event)
-            msg = "Plot room for event set to %s: %s (in %s)\n" % (plotroom, plotroom.ansi_name(),
-                                                                   plotroom.get_detailed_region_name())
-            msg += "If you wish to remove the plotroom later, use this command with no left-hand-side argument."
+            msg = ("Plot room for event set to %s: %s (in %s)\nIf you wish to remove the plotroom later, "
+                   "use this command with no left-hand-side argument." % (plotroom, plotroom.ansi_name(),
+                                                                          plotroom.get_detailed_region_name()))
             self.msg(msg)
         else:
             self.set_form_or_event_attribute("plotroom", None, event)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When setting an event's location, its plotroom field will be set to 'None' and vice versa.
#### Motivation for adding to Arx
There's no way to nullify the location field in-game, forcing event creation from scratch.
#### Other info (issues closed, discussion etc)
Fast and easy solution, thanks! Closes #195 