### PR TITLE
Order petitions from old to new

### DIFF
--- a/world/petitions/models.py
+++ b/world/petitions/models.py
@@ -201,6 +201,9 @@ class Petition(SharedMemoryModel):
     date_created = models.DateField(auto_now_add=True)
     date_updated = models.DateField(auto_now=True)
 
+    class Meta:
+        ordering = ('-date_updated',)
+
     @property
     def owner(self):
         """Gets first owner, if any"""


### PR DESCRIPTION
added default ordering to the Petitions model to fix #193
