### PR TITLE
Mark investigation inactive when preemptively learning its clue

### DIFF
--- a/web/character/investigation.py
+++ b/web/character/investigation.py
@@ -841,13 +841,7 @@ class CmdInvestigate(InvestigationFormCommand):
 
     @property
     def ap_cost(self):
-        try:
-            cost = 50 - (self.caller.db.skills.get('investigation', 0) * 5)
-            if cost < 0:
-                cost = 0
-            return cost
-        except AttributeError:
-            return 50
+        return Investigation.ap_cost(self.caller)
 
     def list_ongoing_investigations(self):
         qs = self.related_manager.filter(ongoing=True)

--- a/web/character/tests.py
+++ b/web/character/tests.py
@@ -50,6 +50,7 @@ class InvestigationTests(ArxCommandTest):
                                                     "You have shared the clue(s) 'test clue' with Char2.\n"
                                                     "Your note: {}".format("x"*80))
         self.assertEqual(self.roster_entry.action_points, 101)
+        inv1 = self.roster_entry2.investigations.create(clue_target=self.clue2, active=True)
         self.call_cmd("/share 2=Testaccount2", "No clue found by this ID: 2. ")
         self.clue_disco2 = self.roster_entry.clue_discoveries.create(clue=self.clue2, message="additional text test2")
         self.assertFalse(bool(self.roster_entry2.revelations.all()))
@@ -59,6 +60,11 @@ class InvestigationTests(ArxCommandTest):
         self.node.discovered_by_revelations.add(self.revelation)
         self.call_cmd(template.format("2", "Love Tehom"*8), "You use 101 action points and have 0 remaining this week.|"
                       "You have shared the clue(s) 'test clue2' with Char2.\nYour note: {}".format("Love Tehom"*8))
+        self.assertTrue(self.account2.informs.filter(message="After a recent clue discovery, "
+                                                             "%s is no longer active." % inv1).exists())
+        self.assertFalse(inv1.active)
+        self.assertEqual(inv1.clue_target, None)
+        self.assertEqual(self.roster_entry2.action_points, 50)
         pract = self.char2.practitioner
         self.assertEqual(pract.spells.first(), self.spell)
         self.assertEqual(pract.nodes.first(), self.node)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When a clue discovery occurs, we'll now mark our investigations that targeted it as inactive instead of just removing their clue_target. This forces a new clue_target acquisition if the user chooses to mark it active again. Also adding a unit test for it.
#### Motivation for adding to Arx
Simply removing the target bypassed the "no clueless investigations" admin setting.