### PR TITLE
Add area to org pages

### DIFF
--- a/web/help_topics/templates/help_topics/org.html
+++ b/web/help_topics/templates/help_topics/org.html
@@ -79,6 +79,7 @@
       <p>Description: {{ domain.desc|mush_to_html}}</p>
       {% if show_secret < 11  %}
           <ul class="list-inline text-left">
+          <li>Area: {{domain.area}}</li>
           <li>Mines: {{domain.num_mines}}</li>
           <li>Lumber: {{domain.num_lumber_yards}}</li>
           <li>Mills: {{domain.num_mills}}</li>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds domain area to org page.

#### Motivation for adding to Arx

I like being able to see a summary of domain stuff on the org page, and area was missing.

#### Other info (issues closed, discussion etc)
