### PR TITLE
Remove caller argument from appsmanager to prevent constraint errors

### DIFF
--- a/commands/base_commands/guest.py
+++ b/commands/base_commands/guest.py
@@ -962,7 +962,7 @@ class CmdGuestAddInput(ArxPlayerCommand):
             caller.msg("You still must define the following fields: %s" % unfinished_values)
             return
         # finish up
-        apps = get_apps_manager(caller)
+        apps = get_apps_manager()
         if not apps:
             caller.msg("Failed to find application manager. Please inform admins.")
             return

--- a/commands/base_commands/jobs.py
+++ b/commands/base_commands/jobs.py
@@ -24,14 +24,14 @@ from typeclasses.bulletin_board.bboard import BBoard
 from typeclasses.managers.apps_manager import AppsManager
 
 
-def get_apps_manager(caller):
+def get_apps_manager():
     """
     returns apps manager object
     """
     try:
         return AppsManager.objects.get()
     except AppsManager.DoesNotExist:
-        return create_object(AppsManager, key="Apps Manager", home=caller, location=caller)
+        return create_object(AppsManager, key="Apps Manager", home=None, location=None)
     except AppsManager.MultipleObjectsReturned:
         return AppsManager.objects.first()
 
@@ -409,7 +409,7 @@ class CmdApp(ArxPlayerCommand):
         caller = self.caller
         args = self.args
         switches = self.switches
-        apps = get_apps_manager(caller)
+        apps = get_apps_manager()
         if not apps:
             caller.msg("Apps manager not found! Please inform the administrators.")
             return

--- a/commands/base_commands/roster.py
+++ b/commands/base_commands/roster.py
@@ -293,7 +293,7 @@ class CmdRosterList(ArxPlayerCommand):
                            " why you want to play the character, how you intend to roleplay them, etc.{n")
                 return
             char_name = char_name.lower()
-            apps = get_apps_manager(caller)
+            apps = get_apps_manager()
             if not apps:
                 caller.msg("Application manager not found! Please inform the admins.")
                 return
@@ -406,7 +406,7 @@ class CmdAdminRoster(ArxPlayerCommand):
                 self.msg("Could not find a character by that name.")
             # try to delete any apps
             from .jobs import get_apps_manager
-            apps = get_apps_manager(caller)
+            apps = get_apps_manager()
             if not apps:
                 return
             apps_for_char = apps.view_all_apps_for_char(args)


### PR DESCRIPTION
Prevents a constraint error when apps manager was created.
