### PR TITLE
Change flashback navigation

### DIFF
--- a/web/character/templates/character/flashbackpost_form.html
+++ b/web/character/templates/character/flashbackpost_form.html
@@ -2,7 +2,7 @@
 {% load app_filters %}
 {% block content %}
     <div class="container">
-        <a href="{% url "character:sheet" character.id %}">&laquo;&nbsp;Back to {{ character.key }}</a>
+        <a href="{% url "character:list_flashbacks" character.id %}">&laquo;&nbsp;Back to flashbacks</a>
         <h2 class="text-center">{{ flashback }}</h2>
         <div class="well text-center">
             {{ flashback.summary|mush_to_html }}
@@ -25,7 +25,7 @@
         </div>
         {% endfor %}
 
-        <a href="{% url "character:sheet" character.id %}">&laquo;&nbsp;Back to {{ character.key }}</a>
+        <a href="{% url "character:list_flashbacks" character.id %}">&laquo;&nbsp;Back to flashbacks</a>
 
         {% if allow_add_post %}
         <div id="add_post" class="dividingBorderAbove">


### PR DESCRIPTION
Change the 'Back to' navigation to go to flashbacks instead of the character page.

#### Brief overview of PR changes/additions

This changes the flashback page template to link back to the flashback list rather than the character page.

#### Motivation for adding to Arx

With multiple ongoing flashbacks I find that I would like to have a link back to the list of flashbacks rather than the character page. That is less clicking and scrolling.