### PR TITLE
Petition Informs fix

### DIFF
--- a/paxforms/paxform_commands.py
+++ b/paxforms/paxform_commands.py
@@ -9,7 +9,8 @@ class PaxformCommand(ArxCommand):
     def __init__(self):
         super(ArxCommand, self).__init__()
         self._form = self.__class__.form_class()
-        if not self.__doc__ or len(self.__doc__) == 0:
+        doc = self.__doc__
+        if not doc or len(doc) == 0 or doc == ArxCommand.__doc__:
             self.__doc__ = self.__docstring
         self._extras = None
 

--- a/world/dominion/setup_utils.py
+++ b/world/dominion/setup_utils.py
@@ -475,6 +475,7 @@ def setup_dom_for_char(character, create_dompc=True, create_assets=True,
     if create_assets:
         amt = starting_money(srank)
         setup_assets(dompc, amt)
+    dompc.petition_settings.get_or_create()
     # if region is provided, we will setup a domain unless explicitly told not to
     if create_domain and region:       
         if character.db.gender and character.db.gender.lower() == 'male':

--- a/world/petitions/petitions_commands.py
+++ b/world/petitions/petitions_commands.py
@@ -10,7 +10,7 @@ from server.utils.prettytable import PrettyTable
 from world.petitions.forms import PetitionForm
 from world.petitions.exceptions import PetitionError
 from world.petitions.models import BrokeredSale, Petition, PetitionSettings, PetitionParticipation
-from world.dominion.models import Organization
+from world.dominion.models import Organization, Member
 from datetime import date
 
 
@@ -230,9 +230,10 @@ class CmdPetition(RewardRPToolUseMixin, ArxCommand):
             self.msg("Successfully created petition %s." % petition.id)
             self.caller.attributes.remove("petition_form")
             if petition.organization is not None:
+                members = Member.objects.filter(organization=petition.organization, deguilded=False)
                 targets = (PetitionSettings.objects.all().exclude(ignored_organizations=petition.organization)
                                                          .exclude(inform=False)
-                                                         .filter(owner__memberships__organization=petition.organization)
+                                                         .filter(owner__memberships__in=members)
                            )
                 targets = [ob for ob in targets if petition.organization.access(petition.owner, "view_petition")]
                 for target in targets:

--- a/world/petitions/tests.py
+++ b/world/petitions/tests.py
@@ -196,6 +196,8 @@ class TestPetitionCommands(ArxCommandTest):
         self.assertTrue(pet.closed)
         self.call_cmd("/reopen 1", "You have reopened the petition.")
         self.assertFalse(pet.closed)
+        org.members.create(player=self.dompc2, rank=4, deguilded=True)
+        self.dompc2.petition_settings.get_or_create()
         self.call_cmd("/submit", "You must create a form first.")
         self.call_cmd("/create", 'Petition Being Created:\nTopic: None\nDescription: None')
         self.call_cmd("/create", 'Petition Being Created:\nTopic: None\nDescription: None\n|'
@@ -211,11 +213,13 @@ class TestPetitionCommands(ArxCommandTest):
         self.call_cmd("/submit", "Successfully created petition 2.")
         self.assertEqual(self.char.db.petition_form, None)
         self.char.db.petition_form = {'topic': 'test2', 'description': 'testing2', 'organization': org.id}
+        self.account2.inform = Mock()
         org.inform = Mock()
         self.call_cmd("/submit", "Successfully created petition 3.")
         self.call_cmd("/search testing2=test org", 'Updated  ID Owner       Topic Org      On \n'+date.today().strftime("%m/%d/%y")+' 3  Testaccount test2 test org')
         self.call_cmd("/search test2", 'Updated  ID Owner       Topic Org      On \n'+date.today().strftime("%m/%d/%y")+' 3  Testaccount test2 test org')
         self.call_cmd("/search asdfadsf", "Updated ID Owner Topic Org On")
         org.inform.assert_called_with('A new petition has been made by Testaccount.', category='Petitions')
+        self.account2.inform.assert_not_called()
         self.call_cmd("/ignore all", "You are now not informed of new petitions.")
         self.call_cmd("/ignore all", "You are now informed of new petitions.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In the Petition submit command, excludes deguilded org members from being informed. Also adds a test. And finally, setting up Dominion features for new characters will quietly create PetitionSettings for them, so they receive informs by default.
#### Motivation for adding to Arx
Fixes a bug and adjusts petition inform behavior to act more intuitively
#### Other info (issues closed, discussion etc)
Resolves #215 