### PR TITLE
override twisted err message in scripts

### DIFF
--- a/typeclasses/scripts/scripts.py
+++ b/typeclasses/scripts/scripts.py
@@ -12,9 +12,10 @@ just overloads its hooks to have it perform its function.
 
 """
 
-from evennia.scripts.scripts import DefaultScript, ExtendedLoopingCall
-from evennia.scripts.models import ScriptDB
 from evennia.comms import channelhandler
+from evennia.scripts.models import ScriptDB
+from evennia.scripts.scripts import DefaultScript
+from evennia.utils import logger
 
 _SESSIONS = None
 
@@ -92,7 +93,13 @@ class Script(DefaultScript):
       at_server_shutdown() - called at a full server shutdown.
 
     """
-    pass
+    def _step_errback(self, e):
+        """
+        Override to keep the user from getting useless script error, plus grabs
+        real traceback for the log.
+        """
+        estring = e.getTraceback()
+        logger.log_err(estring)
 
 
 class CheckSessions(Script):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Overrides twisted error message method to give a full traceback; to the log, not to the user.
#### Motivation for adding to Arx
The single line error is not helpful to trace script bugs.

