### PR TITLE
Fix shop recipe availability

### DIFF
--- a/commands/cmdsets/home.py
+++ b/commands/cmdsets/home.py
@@ -1214,6 +1214,16 @@ class CmdBuyFromShop(CmdCraft):
             caller.msg(obj.return_appearance(caller))
             return
         if set(self.switches) & set(self.crafting_switches + ("craft",)):
+            try:
+                recipe = caller.player_ob.Dominion.assets.recipes.all().get(name__iexact=self.args)
+            except CraftingRecipe.DoesNotExist:
+                caller.msg("No recipe found by the name %s." % self.args)
+                return
+            prices = loc.db.crafting_prices or {}
+            removed = prices.get("removed", [])
+            if recipe.id in removed:
+                caller.msg("Recipe by the name %s is not available." % self.args)
+                return
             return CmdCraft.func(self)
         caller.msg("Invalid switch.")
 

--- a/commands/cmdsets/tests.py
+++ b/commands/cmdsets/tests.py
@@ -4,7 +4,7 @@ Tests for different command sets.
 from mock import patch, Mock
 
 from server.utils.test_utils import ArxCommandTest
-from . import combat, market
+from . import combat, market, home
 
 
 # noinspection PyUnresolvedReferences
@@ -607,3 +607,24 @@ class TestMarketCommands(ArxCommandTest):
                                                 category='Deal Offer')
         self.call_cmd("/findseller testium,testaccount2=50,25",
                       "They already have a deal in progress. Ask them to decline it first.")
+
+class TestHomeCommands(ArxCommandTest):
+    def test_cmd_shop(self):
+        from world.dominion.models import CraftingRecipe
+        recipes = {CraftingRecipe.objects.create(id=1, name="Item1"),  
+                   CraftingRecipe.objects.create(id=2, name="Item2")}
+        self.char.player_ob.Dominion.assets.recipes.set(recipes)
+        prices = self.room.db.crafting_prices or {}
+        prices[1] = 10
+        prices["removed"] = {2}
+        self.room.db.crafting_prices = prices
+        self.room.db.shopowner = self.char
+        self.char.location = self.room
+        self.setup_cmd(home.CmdBuyFromShop, self.char)
+        self.call_cmd("/test", "Invalid switch.")
+        self.call_cmd("/craft Item2", "Recipe by the name Item2 is not available.")
+        self.call_cmd("/craft Item3", "No recipe found by the name Item3.")
+        self.call_cmd("", 'Crafting Prices\n\nName  Craft Price Refine Price \n'
+                          'Item1 0.0         0            \nItem Prices')
+        self.call_cmd("/craft Item1", 'You have started to craft: Item1.|'
+                                      'To finish it, use /finish after you gather the following:|Silver: 10')                 

--- a/commands/cmdsets/tests.py
+++ b/commands/cmdsets/tests.py
@@ -611,7 +611,7 @@ class TestMarketCommands(ArxCommandTest):
 class TestHomeCommands(ArxCommandTest):
     def test_cmd_shop(self):
         from world.dominion.models import CraftingRecipe
-        recipes = {CraftingRecipe.objects.create(id=1, name="Item1"),  
+        recipes = {CraftingRecipe.objects.create(id=1, name="Item1", additional_cost=10),  
                    CraftingRecipe.objects.create(id=2, name="Item2")}
         self.char.player_ob.Dominion.assets.recipes.set(recipes)
         prices = self.room.db.crafting_prices or {}
@@ -625,6 +625,6 @@ class TestHomeCommands(ArxCommandTest):
         self.call_cmd("/craft Item2", "Recipe by the name Item2 is not available.")
         self.call_cmd("/craft Item3", "No recipe found by the name Item3.")
         self.call_cmd("", 'Crafting Prices\n\nName  Craft Price Refine Price \n'
-                          'Item1 0.0         0            \nItem Prices')
+                          'Item1 11.0        0            \nItem Prices')
         self.call_cmd("/craft Item1", 'You have started to craft: Item1.|'
                                       'To finish it, use /finish after you gather the following:|Silver: 10')                 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added a check that validates the availability of a recipe in a shop before passing the arguments to `craft`. Also added a few tests for the `Shop` CmdSet.
#### Motivation for adding to Arx
Bugfixing is fun for the whole family.
#### Other info (issues closed, discussion etc)
Should close issue #243 