### PR TITLE
Feature: Channel mentions

### DIFF
--- a/commands/base_commands/general.py
+++ b/commands/base_commands/general.py
@@ -67,6 +67,7 @@ class CmdGameSettings(ArxPlayerCommand):
         @settings/name_color <color string>
         @settings/verbose_where
         @settings/emit_label
+        @settings/highlight_all_mentions
 
     Switches: /brief suppresses room descs when moving through rooms.
     /posebreak adds a newline between poses from characters.
@@ -87,6 +88,7 @@ class CmdGameSettings(ArxPlayerCommand):
     /verbose_where shows any roomtitle information that someone has set
         about their current activities, when using the +where command.
     /emit_label will prefix each emit with its author.
+    /highlight_all_mentions enables highlighting for all mentions in channels.
     """
     key = "@settings"
     locks = "cmd:all()"
@@ -96,7 +98,7 @@ class CmdGameSettings(ArxPlayerCommand):
                       'afk', 'nomessengerpreview', 'bbaltread', 'ignore_messenger_notifications',
                       'ignore_messenger_deliveries', 'newline_on_messages', 'private_mode',
                       'ic_only', 'ignore_bboard_notifications', 'quote_color', 'name_color',
-                      'emit_label', 'ignore_weather', 'ignore_model_emits')
+                      'emit_label', 'ignore_weather', 'ignore_model_emits', "highlight_all_mentions")
 
     def func(self):
         """Executes setting command"""
@@ -167,6 +169,9 @@ class CmdGameSettings(ArxPlayerCommand):
             return
         if "ignore_model_emits" in switches:
             self.togglesetting(char, "ignore_model_emits")
+            return
+        if "highlight_all_mentions" in switches:
+            self.togglesetting(caller, "highlight_all_mentions")
             return
         caller.msg("Invalid switch. Valid switches are: %s" % ", ".join(self.valid_switches))
 

--- a/typeclasses/channels.py
+++ b/typeclasses/channels.py
@@ -272,9 +272,10 @@ class Channel(DefaultChannel):
         
         for entity in subs:
             if entity in msgobj.senders or entity.player_ob.db.highlight_all_mentions:
-                msgobj.message = self.__format_mentions(msgobj.message, [entity.char_ob.key for entity in subs])
+                names = [sub.char_ob.key for sub in subs]
             else:
-                msgobj.message = self.__format_mentions(msgobj.message, [entity.char_ob.key])
+                names = [entity.char_ob.key]
+            msgobj.message = self.__format_mentions(msgobj.message, names)
 
             self.send_msg(entity, msgobj)
 

--- a/typeclasses/channels.py
+++ b/typeclasses/channels.py
@@ -222,12 +222,14 @@ class Channel(DefaultChannel):
                 return mention
         return None
 
-    def __format_mentions(self, message, name):
+    def __format_mentions(self, message, names):
         """
         Looks through a message for words starting with '@' and
         mentioning a user's name. Highlights them if found.
         """
-        mentions = [mention for mention in self.mentions + [name] if mention in message]
+        if '@' not in message:
+            return message
+        mentions = [mention for mention in self.mentions + names if mention in message]
         if not mentions:
             return message
 
@@ -269,7 +271,11 @@ class Channel(DefaultChannel):
             subs = self.subscriptions.all()
         
         for entity in subs:
-            msgobj.message = self.__format_mentions(msgobj.message, entity.char_ob.key)
+            if entity in msgobj.senders or entity.player_ob.db.highlight_all_mentions:
+                msgobj.message = self.__format_mentions(msgobj.message, [entity.char_ob.key for entity in subs])
+            else:
+                msgobj.message = self.__format_mentions(msgobj.message, [entity.char_ob.key])
+
             self.send_msg(entity, msgobj)
 
         if msgobj.keep_log:

--- a/typeclasses/channels.py
+++ b/typeclasses/channels.py
@@ -245,7 +245,6 @@ class Channel(DefaultChannel):
             senders = ", ".join(senders)
             return self.pose_transform(msg, senders)
 
-
     def tempmsg(self, message, header=None, senders=None):
         """
         A wrapper for sending non-persistent messages. Note that this will

--- a/typeclasses/channels.py
+++ b/typeclasses/channels.py
@@ -269,7 +269,7 @@ class Channel(DefaultChannel):
             subs = self.subscriptions.all()
         
         for entity in subs:
-            msgobj.message = self.__format_mentions(msgobj.message, entity.char_ob.name)
+            msgobj.message = self.__format_mentions(msgobj.message, entity.char_ob.key)
             self.send_msg(entity, msgobj)
 
         if msgobj.keep_log:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added a private method to the `Channel` class, which looks through a message for mentions of users starting with `@` and highlights them if found.
#### Motivation for adding to Arx
Fairly often there might be more than one ongoing conversation in any given channel (especially Info) and it's quite hard to tell who is talking to who, even if they mention their name directly. Using an `@` symbol for this purpose is probably akin to muscle memory for a lot of people.
#### Other info (issues closed, discussion etc)
The formatting is obviously subject to change, I just picked cyan for the sake of consistency. Something like `{c[Name]{n` could possibly be good as well.

A possible issue could be the ability to see who's online, if they're using `watch/hide` (`subscriptions.online()` might take care of that?) or using it to find out who belongs to what org, if the members are secret for some reason (i.e. Shadow Court), though I'm not sure if the those are that problematic.