### PR TITLE
Petition inform fixes (#194)

### DIFF
--- a/world/petitions/petitions_commands.py
+++ b/world/petitions/petitions_commands.py
@@ -235,7 +235,7 @@ class CmdPetition(RewardRPToolUseMixin, ArxCommand):
                                                          .exclude(inform=False)
                                                          .filter(owner__memberships__in=members)
                            )
-                targets = [ob for ob in targets if petition.organization.access(petition.owner, "view_petition")]
+                targets = [ob for ob in targets if petition.organization.access(ob.owner, "view_petition")]
                 for target in targets:
                     target.owner.player.msg("{wA new petition was posted by %s to %s.{n" % (petition.owner,
                                                                                             petition.organization))
@@ -296,14 +296,20 @@ class CmdPetition(RewardRPToolUseMixin, ArxCommand):
         settings, created = self.caller.dompc.petition_settings.get_or_create()
         if self.lhs == "all":
             settings.inform ^= True
-            self.msg("You are now %sinformed of new petitions." % ("" if settings.inform else "not "))
+            self.msg("You are %s informed of new petitions." % ("now" if settings.inform else "no longer"))
+            settings.save()
         elif self.lhs == "general":
             settings.ignore_general ^= True
-            self.msg("You are now %sinformed of new general petitions." % ("" if settings.inform else "not "))
+            self.msg("You are %s informed of new general petitions." % ("no longer" if settings.ignore_general else "now"))
+            settings.save()
         else:
             org = self.get_org_from_args(self.lhs)
-            settings.ignored_organizations.add(org)
-            msg = "You are now %sinformed of new " % ("" if settings.inform else "not ")
+            if org in settings.ignored_organizations.all():
+                settings.ignored_organizations.remove(org)
+                msg = "You are now informed of new "
+            else:
+                settings.ignored_organizations.add(org)
+                msg = "You are no longer informed of new "
             self.msg(msg + self.lhs + " petitions.")
 
     def get_org_from_args(self, args):

--- a/world/petitions/tests.py
+++ b/world/petitions/tests.py
@@ -157,7 +157,7 @@ class TestPetitionCommands(ArxCommandTest):
         self.assertEqual(self.char1.currency, 31925)
 
     def test_cmd_petition(self):
-        
+
         from world.petitions.models import Petition, PetitionParticipation
         from world.dominion.models import Organization
         self.setup_cmd(petitions_commands.CmdPetition, self.char1)
@@ -221,5 +221,58 @@ class TestPetitionCommands(ArxCommandTest):
         self.call_cmd("/search asdfadsf", "Updated ID Owner Topic Org On")
         org.inform.assert_called_with('A new petition has been made by Testaccount.', category='Petitions')
         self.account2.inform.assert_not_called()
-        self.call_cmd("/ignore all", "You are now not informed of new petitions.")
+
+        self.caller = self.char2
+        self.account2.inform = Mock()
+        self.call_cmd("/ignore all", "You are no longer informed of new petitions.")
+
+        self.caller = self.char1
+        self.char.db.petition_form = {'topic': 'test2', 'description': 'testing2'}
+        self.call_cmd("/submit", "Successfully created petition 4.")
+        self.account2.inform.assert_not_called()
+
+        self.caller = self.char2
+        self.account2.inform = Mock()
         self.call_cmd("/ignore all", "You are now informed of new petitions.")
+
+        self.caller = self.char1
+        self.char.db.petition_form = {'topic': 'test2', 'description': 'testing2'}
+        self.call_cmd("/submit", "Successfully created petition 5.")
+        self.account2.inform.assert_called()
+
+        self.caller = self.char2
+        self.account2.inform = Mock()
+        self.call_cmd("/ignore general", "You are no longer informed of new general petitions.")
+
+        self.caller = self.char1
+        self.char.db.petition_form = {'topic': 'test2', 'description': 'testing2'}
+        self.call_cmd("/submit", "Successfully created petition 6.")
+        self.account2.inform.assert_not_called()
+
+        self.caller = self.char2
+        self.account2.inform = Mock()
+        self.call_cmd("/ignore general", "You are now informed of new general petitions.")
+
+        self.caller = self.char1
+        self.char.db.petition_form = {'topic': 'test2', 'description': 'testing2'}
+        self.call_cmd("/submit", "Successfully created petition 7.")
+        self.account2.inform.assert_called()
+
+        self.caller = self.char1
+        self.call_cmd("/ignore test org", "You are no longer informed of new test org petitions.")
+
+        self.caller = self.char2
+        self.account1.inform = Mock()
+        self.char2.db.petition_form = {'topic': 'test2', 'description': 'testing2', 'organization': org.id}
+        self.call_cmd("/submit", "Successfully created petition 8.")
+        self.account1.inform.assert_not_called()
+
+        self.caller = self.char1
+        self.call_cmd("/ignore test org", "You are now informed of new test org petitions.")
+
+        self.caller = self.char2
+        self.account1.inform = Mock()
+        self.char2.db.petition_form = {'topic': 'test2', 'description': 'testing2', 'organization': org.id}
+        self.call_cmd("/submit", "Successfully created petition 9.")
+        self.account1.inform.assert_called()
+


### PR DESCRIPTION
#### Brief overview of PR changes/additions

* Saves changes to the petition settings
* Adds tests
* Checks the inform target for permission to view_petitions when it's an org petition, rather than the petition owner

#### Motivation for adding to Arx

Fixing bug :D