### PR TITLE
Remove 'Favor' from bonus commands

### DIFF
--- a/commands/base_commands/social.py
+++ b/commands/base_commands/social.py
@@ -2781,7 +2781,7 @@ class CmdRandomScene(ArxCommand):
     NUM_DAYS = 3
     DAYS_FOR_NEWBIE_CHECK = 14
     random_rp_command_keys = ["knock", "shout", "mutter", "petition", "goals", "+plots", "+room_mood", "+roomtitle",
-                              "+tempdesc", "flashback", "favor"]
+                              "+tempdesc", "flashback"]
 
     @property
     def scenelist(self):

--- a/commands/cmdsets/standard.py
+++ b/commands/cmdsets/standard.py
@@ -192,7 +192,7 @@ class OOCCmdSet(CmdSet):
         self.add(social.CmdSocialNotable())
         self.add(social.CmdSocialNominate())
         self.add(social.CmdSocialReview())
-        # self.add(social.CmdFavor())
+        # self.add(social.CmdFavor())  #when enabled, please re-add "favor" to random_rp_command_keys in CmdRandomScene
         self.add(overrides.SystemNoMatch())
         self.add(weather_commands.CmdAdminWeather())
         self.add(roster.CmdPropriety())


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes "favor" from the pool of possible RP commands that grant XP each week. Adds a reminder beside the disabled command to re-add it later, after it's been restored.
#### Motivation for adding to Arx
Players were encouraged to use a disabled command and this blocked bonus XP.