### PR TITLE
Petition # Display && @check/vs Display

### DIFF
--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -29,5 +29,6 @@ jobs:
 
       - name: Send to Coveralls
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: coveralls

--- a/world/petitions/forms.py
+++ b/world/petitions/forms.py
@@ -25,7 +25,9 @@ class PetitionForm(ModelForm):
         org = self.cleaned_data.get("organization")
         if org:
             org.inform(
-                "A new petition has been made by %s." % self.owner, category="Petitions"
+                "A new petition has been made by %s.  Type 'petition %s' to read it."
+                % (self.owner, petition.id),
+                category="Petitions",
             )
         return petition
 

--- a/world/petitions/tests.py
+++ b/world/petitions/tests.py
@@ -399,7 +399,8 @@ class TestPetitionCommands(ArxCommandTest):
         )
         self.call_cmd("/search asdfadsf", "Updated ID Owner Topic Org On")
         org.inform.assert_called_with(
-            "A new petition has been made by Testaccount.", category="Petitions"
+            "A new petition has been made by Testaccount.  Type 'petition 3' to read it.",
+            category="Petitions",
         )
         self.account2.inform.assert_not_called()
 

--- a/world/stat_checks/check_commands.py
+++ b/world/stat_checks/check_commands.py
@@ -145,7 +145,7 @@ class CmdStatCheck(ArxCommand):
             rolls.append(
                 SimpleRoll(character=arg[0], stat=stat, skill=skill, rating=rating)
             )
-        OpposingRolls(rolls[0], rolls[1], self.caller).announce()
+        OpposingRolls(rolls[0], rolls[1], self.caller, target).announce()
 
 
 class CmdHarm(ArxCommand):

--- a/world/stat_checks/check_maker.py
+++ b/world/stat_checks/check_maker.py
@@ -307,10 +307,11 @@ class ContestedCheckMaker:
 
 
 class OpposingRolls:
-    def __init__(self, roll1, roll2, caller):
+    def __init__(self, roll1, roll2, caller, target):
         self.roll1 = roll1
         self.roll2 = roll2
         self.caller = caller
+        self.target = target
 
     def announce(self):
         self.roll1.execute()
@@ -319,9 +320,9 @@ class OpposingRolls:
             [self.roll1, self.roll2], key=lambda x: x.result_value, reverse=True
         )
         if check_rolls_tied(self.roll1, self.roll2):
-            result = "The rolls are tied."
+            result = "*** The rolls are |ctied|n. ***"
         else:
-            result = f"{rolls[0].character} is the winner."
-        msg = f"{self.caller} has called for an opposing check. "
-        msg += f"{self.roll1.roll_message} {self.roll2.roll_message}\n{result}"
+            result = f"*** |c{rolls[0].character}|n is the winner. ***"
+        msg = f"\n|w*** {self.caller} has called for an opposing check with {self.target}. ***|n\n"
+        msg += f"{self.roll1.roll_message}\n{self.roll2.roll_message}\n{result}"
         self.caller.msg_location_or_contents(msg, options={"roll": True})

--- a/world/stat_checks/tests.py
+++ b/world/stat_checks/tests.py
@@ -147,14 +147,18 @@ class TestCheckCommands(ArxCommandTest):
         self.call_cmd(f"/vs blah blah={self.char2}", "Must provide two checks.")
         self.call_cmd(f"/vs dex + melee vs intelligence={self.char2}", "")
         self.mock_announce.assert_called_with(
-            "Char has called for an opposing check. Char checks dex and melee at easy. Char rolls marginal. "
-            "Char2 checks intelligence at easy. Char2 rolls marginal.\nThe rolls are tied.",
+            "\n|w*** Char has called for an opposing check with Char2. ***|n\n"
+            "Char checks dex and melee at easy. Char rolls marginal.\n"
+            "Char2 checks intelligence at easy. Char2 rolls marginal.\n"
+            "*** The rolls are |ctied|n. ***",
             options=self.options,
         )
         self.char2.traits.set_stat_value("intelligence", 50)
         self.call_cmd(f"/vs dex + melee vs intelligence={self.char2}", "")
         self.mock_announce.assert_called_with(
-            "Char has called for an opposing check. Char checks dex and melee at easy. Char rolls marginal. "
-            "Char2 checks intelligence at easy. Char2 rolls okay.\nChar2 is the winner.",
+            "\n|w*** Char has called for an opposing check with Char2. ***|n\n"
+            "Char checks dex and melee at easy. Char rolls marginal.\n"
+            "Char2 checks intelligence at easy. Char2 rolls okay.\n"
+            "*** |cChar2|n is the winner. ***",
             options=self.options,
         )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
\- Displays ID # of new petitions so receivers can quickly identify which petition was just created.
\- Improved display of @check/vs.

OLD
\<DiceString> Name has called for an opposing check with Name 2. Name rolls strength at easy. Name rolls marginal. Name2 rolls strength at easy. Name2 rolls okay.
Name is the winner.

NEW
\<DiceString>
*** Name has called for an opposing check with Name2. *** (<- all colored white to draw attention to it)
Name rolls strength at easy. Name rolls marginal.
Name2 rolls strength at easy. Name2 rolls okay.
*** Name2 is the winner. *** (<- the winning name (or 'tied') is colored to draw attention to the result)

#### Motivation for adding to Arx
So I can learn more about how things work so I know what not to touch. :)

#### Other info (issues closed, discussion etc)
Closes #320.

I would appreciate a second pair of eyes on the petition one; it passed testing with what I expected to happen ("petition 3" == "petition.id == 3") but since @informs seem to behave a little different I'm a bit shaky here.