### PR TITLE
Private roll display adjustment

### DIFF
--- a/world/stat_checks/tests.py
+++ b/world/stat_checks/tests.py
@@ -85,7 +85,7 @@ class TestCheckCommands(ArxCommandTest):
         )
 
     def test_stat_check_cmd_private(self, mock_randint):
-        # Test private roll messaging
+        """Test private roll messaging."""
         # Self-only private roll.
         mock_randint.return_value = 25
         self.call_cmd(
@@ -94,16 +94,10 @@ class TestCheckCommands(ArxCommandTest):
         )
 
         # Sharing with another character.
-        # Note that the 'me' gets removed because it's redundant.
+        # Note that Char shows up last because of being a staff-flagged PC.
         self.call_cmd(
             "dex at normal=me,char2",
-            f"[Private Roll] {self.char1} checks dex at {self.normal}. {self.char1} rolls marginal. (Shared with: Char2)",
-        )
-
-        # Test that copy-pasting names aren't going to spam.
-        self.call_cmd(
-            "dex at normal=char2,char2",
-            f"[Private Roll] {self.char1} checks dex at {self.normal}. {self.char1} rolls marginal. (Shared with: Char2)",
+            f"[Private Roll] {self.char1} checks dex at {self.normal}. {self.char1} rolls marginal. (Shared with: Char2, Char)",
         )
 
     def test_stat_check_cmd_contest(self, mock_randint):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This modifies how names are displayed for making private rolls with new @check.  I also cleaned up the code a little and took out some redundancies, including one of my meaningless tests.

OLD: 
\- Would display self-only if you're sending it to yourself and staff (because staff can see it anyway).

NEW:
\- Names are sorted() and grouped by PCs and staff, in that order.
\- Will display staff names if specified to receive a private roll.  Staff names will be listed last in the list as well as have a highlight.  This is done to make it easier to find their names.
\- Self-only will display only if you're sending it to yourself and no one else (but staff will still see it).

#### Motivation for adding to Arx
Player feedback and uncertainty about whether GMs were getting private rolls or not.

#### Other info (issues closed, discussion etc)
