### PR TITLE
@adjust multi-char support

### DIFF
--- a/commands/base_commands/staff_commands.py
+++ b/commands/base_commands/staff_commands.py
@@ -2391,7 +2391,9 @@ class CmdAdjust(ArxPlayerCommand):
             self.caller.msg(error)
 
     def do_adjust_material(self):
+        # Get names and remove empty strings (from comma typos)
         name_list = self.lhs.split(",")
+        name_list = [name for name in name_list if name]
 
         material_name, qty, inform_msg = self._get_material_rhs()
 
@@ -2410,7 +2412,6 @@ class CmdAdjust(ArxPlayerCommand):
         # For each player we're adjusting:
         # - get the account and character (if applicable)
         # - do the adjustment
-        # - build the inform msg sent to the player
         try:
             with transaction.atomic():
                 for name in name_list:
@@ -2426,10 +2427,6 @@ class CmdAdjust(ArxPlayerCommand):
                         fail_list.append(char.key)
         except DatabaseError:
             # If something went wrong, the database should roll back to no changes.
-            # Thus, don't notify anyone.
-            success_list.clear()
-            fail_list.clear()
-            inform_list.clear()
             raise self.error_class(
                 "A database error occurred. No players were adjusted."
             )
@@ -2454,7 +2451,9 @@ class CmdAdjust(ArxPlayerCommand):
             self.caller.msg(f"Failed to adjust: {', '.join(fail_list)}.")
 
     def do_adjust_resource(self):
+        # Get names and remove empty strings (from comma typos)
         name_list = self.lhs.split(",")
+        name_list = [name for name in name_list if name]
 
         resource, qty, inform_msg = self._get_resource_rhs()
 
@@ -2469,7 +2468,6 @@ class CmdAdjust(ArxPlayerCommand):
         # For each player we're adjusting:
         # - get the account and character (if applicable)
         # - do the adjustment
-        # - build the inform msg sent to the player
         try:
             with transaction.atomic():
                 for name in name_list:
@@ -2485,10 +2483,6 @@ class CmdAdjust(ArxPlayerCommand):
                         fail_list.append(char.key)
         except DatabaseError:
             # If something went wrong, the database should roll back to no changes.
-            # Thus, don't notify anyone.
-            success_list.clear()
-            fail_list.clear()
-            inform_list.clear()
             raise self.error_class(
                 "A database error occurred. No players were adjusted."
             )
@@ -2515,7 +2509,9 @@ class CmdAdjust(ArxPlayerCommand):
             self.caller.msg(f"Failed to adjust: {', '.join(fail_list)}.")
 
     def do_adjust_silver(self):
+        # Get names and remove empty strings (from comma typos)
         name_list = self.lhs.split(",")
+        name_list = [name for name in name_list if name]
 
         qty, inform_msg = self._get_silver_rhs()
 
@@ -2526,7 +2522,6 @@ class CmdAdjust(ArxPlayerCommand):
         # For each player we're adjusting:
         # - get the account and character (if applicable)
         # - do the adjustment
-        # - build the inform msg sent to the player
         try:
             with transaction.atomic():
                 for name in name_list:
@@ -2542,10 +2537,6 @@ class CmdAdjust(ArxPlayerCommand):
                         fail_list.append(char.key)
         except DatabaseError:
             # If something went wrong, the database should roll back to no changes.
-            # Thus, don't notify anyone.
-            success_list.clear()
-            fail_list.clear()
-            inform_list.clear()
             raise self.error_class(
                 "A database error occurred. No players were adjusted."
             )

--- a/commands/base_commands/tests.py
+++ b/commands/base_commands/tests.py
@@ -2466,3 +2466,20 @@ class AdjustCommandTests(ArxCommandTest):
         # Test failure with one not-right character.
         result_msg = "Could not find 'foo'.|Awarded 50 silver to: Char2, Char4.|Failed to adjust: foo."
         self.call_cmd("/silver Testaccount2,foo,Testaccount4=50", result_msg)
+
+        self.assertEqual(self.char2.db.currency, 100)
+        self.assertEqual(self.char4.db.currency, 100)
+
+        # Test typo with commas in character names.
+        result_msg = "Deducted 50 silver from: Char2, Char3, Char4."
+        self.call_cmd(
+            "/silver Testaccount2,,Testaccount3,,,Testaccount4=-50", result_msg
+        )
+
+        self.assertEqual(self.char2.db.currency, 50)
+        self.assertEqual(self.char3.db.currency, 0)
+        self.assertEqual(self.char4.db.currency, 50)
+
+        # Test more typos with commas in character names.
+        result_msg = "Could not find 'Testaccount2.Testaccount3'.|Failed to adjust: Testaccount2.Testaccount3."
+        self.call_cmd("/silver Testaccount2.Testaccount3=50", result_msg)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This upgrades the @adjust staff command to support multiple characters on the command line.

#### Motivation for adding to Arx
Apostate said it would be really swell if I could do that, so I did.

#### Other info (issues closed, discussion etc)

Areas needing fine-toothed comb:
- Usage of the transaction.atomic() context manager and its enclosing try/except block.  I'm not 100% certain I have that correct logically.  I'm particularly concerned about the "no one was adjusted" exception being an accurate error to raise, even though I don't foresee it actually happening in practice.
- I am completely reliant upon my test cases for this command upgrade. I wasn't able to really test it in action on my private server due to technical issues on my end that I haven't solved.  Logically they're succeeding, which is heartening, but I'm hoping I didn't forget anything obvious.