### PR TITLE
Changed emit label to differentiate from channel labels

### DIFF
--- a/commands/base_commands/overrides.py
+++ b/commands/base_commands/overrides.py
@@ -543,7 +543,7 @@ class CmdEmit(ArxCommand):
                 for ob in caller.location.contents
                 if "emit_label" in ob.tags.all() and ob.player
             ]
-            gm_msg = "{w[{c%s{w]{n %s" % (caller.name, message)
+            gm_msg = "{w({c%s{w){n %s" % (caller.name, message)
             caller.location.msg_contents(
                 gm_msg, from_obj=caller, options={"is_pose": True}, gm_msg=True
             )

--- a/typeclasses/places/places.py
+++ b/typeclasses/places/places.py
@@ -101,7 +101,7 @@ class Place(Object):
             )
         elif msg_type == self.TT_EMIT:
             if to_obj.tags.get("emit_label"):
-                emit_label = "{w[{c%s{w]{n " % from_obj.name
+                emit_label = "{w({c%s{w){n " % from_obj.name
             else:
                 emit_label = ""
             place_msg = emit_msg.format(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changed emit labels from `[Name]` to `(Name)`, as the former currently matches channel labels, which breaks triggers. Since you're allowed to pose within channels as well, this is virtually impossible to avoid via regex, unless you were to manually specify every channel you want to fall under a trigger.
#### Motivation for adding to Arx
Working triggers maintain the player's sanity level.
#### Other info (issues closed, discussion etc)
Picked parentheses to maintain some similarity to the original label, but could be changed to something that fits better, if there are any alternatives.