### PR TITLE
Proposal: Using Enums for command switches

### DIFF
--- a/commands/base_commands/jobs.py
+++ b/commands/base_commands/jobs.py
@@ -330,7 +330,7 @@ class CmdRequest(ArxPlayerCommand):
         followup = "<#>=<message> | Add a followup message to a request."
         close = "<#>=<reason> | Close a request prematurely and provide a reason."
 
-    switch_options = Switches
+    switch_options = Switches.__members__
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -447,13 +447,13 @@ class CmdRequest(ArxPlayerCommand):
 
     def func(self):
         """Implement the command"""
-        switches = [self.switch_options[string] for string in self.switches]
+        switches = [self.Switches[string] for string in self.switches]
         caller = self.caller
-        if self.switch_options.followup in switches:
+        if self.Switches.followup in switches:
             self.comment_on_ticket()
             return
 
-        if self.switch_options.close in switches:
+        if self.Switches.close in switches:
             self.close_ticket(self.lhs, self.rhs)
             return
 

--- a/commands/mixins.py
+++ b/commands/mixins.py
@@ -12,6 +12,11 @@ class ArxCommmandMixin(object):
     error_class = CommandError
     help_entry_tags = []
 
+    def format_docstring(self):
+        self.__doc__ = self.__doc__ % "%r    ".join(
+            f"{switch.name} {switch.value}" for switch in self.switch_options
+        )
+
     def fail(self, msg):
         """Raises an error for the class with a given message"""
         raise self.error_class(msg)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
An example of an alternative for how Arx handles command switches.
#### Motivation for adding to Arx
After spending some time exploring the code for various commands, it seems to me that the current way Evennia handles command switches tends to completely and utterly destroy code consistency and readability.  Jumping into code for a command you've yet to see, is like diving into a minefield. Standardizing the way we handle switches should drastically improve that and Enums seem like the perfect candidate for the job, especially whenever we decide to move to Python 3.10, which adds `match` statements, making handling this implementation even more of a breeze.

As enums require a default value, that means that we could enforce providing documentation for every switch:
```python
class Switches(Enum):
    followup = "<#>=<message> | Add a followup message to a request."
...
```
This would make helpfiles much more consistent for both the player and the developer.
I provided an example of that in the PR as well.

Thankfully, Evennia already provides us with `switch_options` in `MuxCommand`, however, that field expects a list of strings, but changing that is extremely easy, especially since we use a fork of Evennia anyway.

As it stands, this implementation wouldn't break any commands that don't utilize `self.switch_options` already, letting us port them over at our own pace. In the future, `self.switches` could also be changed to provide us with a list of switches already casted to the Enum provided in `self.switch_options`.