### PR TITLE
Kill unused room attribute!

### DIFF
--- a/commands/cmdsets/home.py
+++ b/commands/cmdsets/home.py
@@ -740,7 +740,7 @@ class CmdManageRoom(ArxCommand):
     def toggle_pets_controls(self, loc):
         "Handles the togglepets switch and returns a string."
         if not self.args:
-            loc.pets_allowed = not loc.pets_allowed
+            loc.pets_banned = not loc.pets_banned
         elif "allowlist" not in self.args:
             characters = []
             for targ in self.lhslist:

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -44,10 +44,10 @@ class Exit(LockMixins, ObjectMixins, DefaultExit):
         if self.destination.check_banned(character):
             character.msg("You have been banned from entering there.")
             return
-        if not self.destination.pets_allowed and character.has_pets:
+        if self.destination.pets_banned and character.has_pets:
             if character.fakename or character not in self.destination.pets_allow_list:
                 character.msg(
-                    "Your pets are not allowed there. (Try 'guards/dismiss'.)"
+                    "Your pets are not allowed there. (Try 'guards/dismiss' first)"
                 )
                 return
         if self.access(character, "traverse"):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -476,10 +476,10 @@ class ArxRoom(ObjectMixins, ExtendedRoom, MagicMixins):
     @property
     def pets_mandate_msg(self):
         "Returns a string about the room's pet allowance."
-        allowed = self.pets_banned
-        mandate = "allows" if allowed else "does not allow"
+        banned = self.pets_banned
+        mandate = "does not allow" if banned else "allows"
         msg = f"{self} {mandate} animal companions."
-        if not allowed and self.pets_allow_list:
+        if banned and self.pets_allow_list:
             msg += f" Exceptions: {list_to_string([ob.key for ob in self.pets_allow_list])}."
         return msg
 

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -446,24 +446,25 @@ class ArxRoom(ObjectMixins, ExtendedRoom, MagicMixins):
         return [ob for ob in self.contents if isinstance(ob, Place)]
 
     @property
-    def pets_allowed(self):
-        "Whether the room allows pets."
-        if self.db.pets_allowed is None:
-            self.db.pets_allowed = True
-        return self.db.pets_allowed
+    def pets_banned(self):
+        "Whether the room permits animal retainers."
+        if self.db.pets_banned is None:
+            return
+        return self.db.pets_banned
 
-    @pets_allowed.setter
-    def pets_allowed(self, bool_val):
-        "Setter. Wipes the allow list when toggled true."
-        self.db.pets_allowed = bool_val
+    @pets_banned.setter
+    def pets_banned(self, bool_val):
+        "Setter. Wipes the allow list when False."
         if bool_val:
-            self.attributes.remove("pets_allow_list")
+            self.db.pets_banned = True
+        else:
+            self.attributes.remove(["pets_banned", "pets_allow_list"])
 
     @property
     def pets_allow_list(self):
         "A list of players bypassing the pet ban."
         if self.db.pets_allow_list is None:
-            self.db.pets_allow_list = []
+            return []
         return self.db.pets_allow_list
 
     @pets_allow_list.setter
@@ -475,7 +476,7 @@ class ArxRoom(ObjectMixins, ExtendedRoom, MagicMixins):
     @property
     def pets_mandate_msg(self):
         "Returns a string about the room's pet allowance."
-        allowed = self.pets_allowed
+        allowed = self.pets_banned
         mandate = "allows" if allowed else "does not allow"
         msg = f"{self} {mandate} animal companions."
         if not allowed and self.pets_allow_list:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the `pets_allowed` room attribute to `pets_banned` and reverses the logic of commands using it.
#### Motivation for adding to Arx
Instead of adding an attribute to every room, this only adds to where the pet-ban will be useful.
#### Other info (issues closed, discussion etc)
🤷‍♀️  Hacktoberfest extra credit?! 🎃 