### PR TITLE
Add setconfig option for bonus ap regen

### DIFF
--- a/commands/base_commands/staff_commands.py
+++ b/commands/base_commands/staff_commands.py
@@ -2107,6 +2107,7 @@ class CmdSetServerConfig(ArxPlayerCommand):
         "new clue ap cost": "NEW_CLUE_AP_COST",
         "material cost multiplier": "MATERIAL_COST_MULTIPLIER",
         "OC": "ALLOW_OC",
+        "ap regen": "BONUS_AP_REGEN",
     }
     valid_keys = sorted(shorthand_to_real_keys.keys())
 
@@ -2166,11 +2167,9 @@ class CmdSetServerConfig(ArxPlayerCommand):
                     val = self.validate_income_value(self.rhs)
                 elif key == "motd":
                     broadcast("|yServer Message of the Day:|n %s" % val)
-                elif key == "ap transfers disabled":
+                elif key in ("ap transfers disabled", "OC"):
                     val = bool(self.rhs)
-                elif key == "OC":
-                    val = bool(self.rhs)
-                elif key in ("cg bonus skill points", "new clue ap cost"):
+                elif key in ("cg bonus skill points", "new clue ap cost", "ap regen"):
                     if not val.isdigit():
                         return self.msg("This must be a number.")
                     val = int(val)

--- a/commands/base_commands/tests.py
+++ b/commands/base_commands/tests.py
@@ -1722,7 +1722,7 @@ class StaffCommandTests(ArxCommandTest):
         self.setup_cmd(staff_commands.CmdSetServerConfig, self.account)
         self.call_cmd(
             "asdf",
-            "Not a valid key: OC, ap transfers disabled, cg bonus skill points, income, "
+            "Not a valid key: OC, ap regen, ap transfers disabled, cg bonus skill points, income, "
             "material cost multiplier, motd, new clue ap cost",
         )
         self.call_cmd(
@@ -1730,6 +1730,7 @@ class StaffCommandTests(ArxCommandTest):
             "| key                                     | value                            "
             "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+\n"
             "| OC                                      | None                             "
+            "| ap regen                                | None                             "
             "| ap transfers disabled                   | None                             "
             "| cg bonus skill points                   | None                             "
             "| income                                  | 5.0                              "
@@ -1742,6 +1743,7 @@ class StaffCommandTests(ArxCommandTest):
             "| key                                     | value                            "
             "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+\n"
             "| OC                                      | None                             "
+            "| ap regen                                | None                             "
             "| ap transfers disabled                   | None                             "
             "| cg bonus skill points                   | 20                               "
             "| income                                  | 5.0                              "

--- a/server/conf/base_settings.py
+++ b/server/conf/base_settings.py
@@ -244,3 +244,4 @@ MIDDLEWARE = [
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
     "web.middleware.auth.SharedLoginMiddleware",
 ]
+SHELL_PLUS_PRINT_SQL = config("SHELL_PLUS_PRINT_SQL", cast=bool, default=False)

--- a/web/character/models.py
+++ b/web/character/models.py
@@ -401,6 +401,7 @@ class RosterEntry(SharedMemoryModel):
     def action_point_regen_modifier(self):
         """AP penalty from our number of fealties"""
         from world.dominion.plots.models import PlotAction, PlotActionAssistant
+        from evennia.server.models import ServerConfig
 
         ap_mod = 0
         # they lose 10 AP per fealty they're in
@@ -411,6 +412,11 @@ class RosterEntry(SharedMemoryModel):
         # gain 20 AP for not having an investigation
         if not self.investigations.filter(active=True).exists():
             ap_mod += 20
+        val = ServerConfig.objects.conf(key="BONUS_AP_REGEN", default=0)
+        try:
+            ap_mod += int(val)
+        except (TypeError, ValueError):
+            pass
 
         return ap_mod
 


### PR DESCRIPTION
AP regen has been modified with the change to plot actions, so I added in a way for staff to set a bonus offset value to the server. Note that ap regen is cached per character, so you'll want to reload the server upon changing it for players to see it.
