### PR TITLE
Fix Togglepets

### DIFF
--- a/commands/cmdsets/home.py
+++ b/commands/cmdsets/home.py
@@ -464,7 +464,7 @@ class CmdManageRoom(ArxCommand):
 
     Togglepets switch controls entry of characters with animals. Comma-separated
     names toggle characters on an allowlist. The list is wiped when toggling
-    the room to allow pets again.
+    the room to allow pets again. (Allowed characters not recognized in disguise)
     """
 
     key = "+manageroom"

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -740,8 +740,9 @@ class Character(
         "Animal or small animal retainers"
         if not self.ndb.followers:
             return
+        loc = self.location
         for follower in self.ndb.followers:
-            if "animal" in str(follower.item_data.race):
+            if loc == follower.location and "animal" in str(follower.item_data.race):
                 return True
 
     def get_directions(self, room):

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -47,9 +47,7 @@ class Exit(LockMixins, ObjectMixins, DefaultExit):
         if self.destination.pets_banned and character.has_pets:
             pet_fail = "Pets are not allowed there. "
             if character not in self.destination.pets_allow_list:
-                character.msg(
-                    f"{pet_fail}(Try 'guards/dismiss' first)"
-                )
+                character.msg(f"{pet_fail}(Try 'guards/dismiss' first)")
                 return
             elif character.fakename:
                 character.msg(

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -45,9 +45,15 @@ class Exit(LockMixins, ObjectMixins, DefaultExit):
             character.msg("You have been banned from entering there.")
             return
         if self.destination.pets_banned and character.has_pets:
-            if character.fakename or character not in self.destination.pets_allow_list:
+            pet_fail = "Pets are not allowed there. "
+            if character not in self.destination.pets_allow_list:
                 character.msg(
-                    "Your pets are not allowed there. (Try 'guards/dismiss' first)"
+                    f"{pet_fail}(Try 'guards/dismiss' first)"
+                )
+                return
+            elif character.fakename:
+                character.msg(
+                    f"{pet_fail}Yours would normally be an exception, but you are not recognized in disguise."
                 )
                 return
         if self.access(character, "traverse"):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -469,9 +469,11 @@ class ArxRoom(ObjectMixins, ExtendedRoom, MagicMixins):
 
     @pets_allow_list.setter
     def pets_allow_list(self, characters):
-        "Setter toggles players on/off the allow list."
-        allowed = [ob for ob in characters if ob not in self.pets_allow_list]
-        self.db.pets_allow_list = allowed
+        "Updates allow list, toggling characters on/off existing list."
+        old_allow = self.db.pets_allow_list or []
+        removals = set([ob for ob in characters if ob in old_allow])
+        both_lists = set(characters + old_allow)
+        self.db.pets_allow_list = [ob for ob in both_lists if ob not in removals]
 
     @property
     def pets_mandate_msg(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes properties related to the `+manageroom/togglepets` switch. Compares the location of pet & owner to determine if pets are following. Adds a verbose error for masked characters. And fixes some logic for the allowlist toggle, allowing names to be added instead of replacing the whole list at each use.
#### Motivation for adding to Arx
Pets are not removed from the list of a character's followers until the person goes somewhere else. After dismissing pets, characters were still not allowed to traverse into a pet-banned room unless they changed rooms first.
#### Other info (issues closed, discussion etc)
✌️ Happy Hackvemberfest?