### PR TITLE
fixed the fealty references to make census work

### DIFF
--- a/commands/base_commands/guest.py
+++ b/commands/base_commands/guest.py
@@ -286,9 +286,9 @@ def census_of_fealty():
     """Returns dict of fealty name to number of active players"""
     fealties = {
         "Valardin": 0,
-        "Velenosa": 0,
+        "Lyceum": 0,
         "Grayson": 0,
-        "Crownsworn": 0,
+        "Crown": 0,
         "Thrax": 0,
         "Redrain": 0,
         "Pravus": 0,


### PR DESCRIPTION
Should be a very simple fix that makes the +census command work again, just changed the references.
