### PR TITLE
Update git actions and upgrade black version

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
       - uses: psf/black@stable
         with:
           version: "21.4b2"
+          black_args: "--check --diff --version"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,5 +12,4 @@ jobs:
           python-version: '3.8'
       - uses: psf/black@stable
         with:
-          version: "21.4b2"
-          options: "--check --diff --version"
+          version: "22.3.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: psf/black@stable
         with:
           version: "21.4b2"
-          black_args: "--check --diff --version"
+          options: "--check --diff --version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 
 WORKDIR /usr/src
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ dnspython==1.16.0
 graphviz==0.13.2
 humanize==0.5.1
 Jinja2==2.11.3
+markupsafe<2.1
 pillow==8.3.2
 python-decouple==3.3
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==21.4b2
+black==22.3.0
 cloudinary==1.19.1
 django-bootstrap-form==3.4
 django-crispy-forms==1.8.1
@@ -7,7 +7,7 @@ dnspython==1.16.0
 graphviz==0.13.2
 humanize==0.5.1
 Jinja2==2.11.3
-markupsafe<2.1
+markupsafe<2.1 # v2.1 removes code used by jinja2 v2.11.3
 pillow==8.3.2
 python-decouple==3.3
 requests==2.22.0

--- a/server/utils/progress_bar.py
+++ b/server/utils/progress_bar.py
@@ -20,7 +20,7 @@ def ProgressBar(percent, prefix=None, notches=50, numericalpercent=True, unicode
     and empty portions, respectively; [unicode] can be set to True to use full and empty
     blocks from the Unicode character set instead, which are not defined in all fonts."""
 
-    outString = u""  # Unicode string.
+    outString = ""  # Unicode string.
     if prefix:
         prefix = "{} ".format(prefix)
         outString = outString + prefix

--- a/web/helpdesk/akismet.py
+++ b/web/helpdesk/akismet.py
@@ -98,7 +98,6 @@ if urllib_request is None:
             "Could not fetch Akismet URL: %s Response code: %s" % (url, req.status_code)
         )
 
-
 else:
 
     def _fetch_url(url, data, headers):

--- a/web/helpdesk/management/commands/get_email.py
+++ b/web/helpdesk/management/commands/get_email.py
@@ -84,7 +84,7 @@ def process_email(quiet=False):
 
 def process_queue(q, quiet=False):
     if not quiet:
-        print "Processing: %s" % q
+        print("Processing: %s" % q)
 
     if q.socks_proxy_type and q.socks_proxy_host and q.socks_proxy_port:
         try:
@@ -190,7 +190,7 @@ def decodeUnknown(charset, string):
 
 def decode_mail_headers(string):
     decoded = decode_header(string)
-    return u" ".join([unicode(msg, charset or "utf-8") for msg, charset in decoded])
+    return " ".join([unicode(msg, charset or "utf-8") for msg, charset in decoded])
 
 
 def ticket_from_message(message, queue, quiet):
@@ -337,7 +337,7 @@ def ticket_from_message(message, queue, quiet):
     f.save()
 
     if not quiet:
-        print (
+        print(
             " [%s-%s] %s"
             % (
                 t.queue.slug,
@@ -359,7 +359,7 @@ def ticket_from_message(message, queue, quiet):
             a.file.save(filename, ContentFile(file["content"]), save=False)
             a.save()
             if not quiet:
-                print "    - %s" % filename
+                print("    - %s" % filename)
 
     context = safe_template_context(t)
 

--- a/web/helpdesk/south_migrations/0008_auto__chg_field_attachment_file__del_unique_ticketcustomfieldvalue_tic.py
+++ b/web/helpdesk/south_migrations/0008_auto__chg_field_attachment_file__del_unique_ticketcustomfieldvalue_tic.py
@@ -8,11 +8,11 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Removing unique constraint on 'TicketCustomFieldValue', fields ['ticket', 'field']
-        db.delete_unique(u"helpdesk_ticketcustomfieldvalue", ["ticket_id", "field_id"])
+        db.delete_unique("helpdesk_ticketcustomfieldvalue", ["ticket_id", "field_id"])
 
         # Changing field 'Attachment.file'
         db.alter_column(
-            u"helpdesk_attachment",
+            "helpdesk_attachment",
             "file",
             self.gf("django.db.models.fields.files.FileField")(max_length=1000),
         )
@@ -21,17 +21,17 @@ class Migration(SchemaMigration):
 
         # Changing field 'Attachment.file'
         db.alter_column(
-            u"helpdesk_attachment",
+            "helpdesk_attachment",
             "file",
             self.gf("django.db.models.fields.files.FileField")(max_length=100),
         )
         # Adding unique constraint on 'TicketCustomFieldValue', fields ['ticket', 'field']
-        db.create_unique(u"helpdesk_ticketcustomfieldvalue", ["ticket_id", "field_id"])
+        db.create_unique("helpdesk_ticketcustomfieldvalue", ["ticket_id", "field_id"])
 
     models = {
-        u"auth.group": {
+        "auth.group": {
             "Meta": {"object_name": "Group"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": (
                 "django.db.models.fields.CharField",
                 [],
@@ -41,13 +41,13 @@ class Migration(SchemaMigration):
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                     "symmetrical": "False",
                     "blank": "True",
                 },
             ),
         },
-        u"auth.permission": {
+        "auth.permission": {
             "Meta": {
                 "ordering": "(u'content_type__app_label', u'content_type__model', u'codename')",
                 "unique_together": "((u'content_type', u'codename'),)",
@@ -61,12 +61,12 @@ class Migration(SchemaMigration):
             "content_type": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['contenttypes.ContentType']"},
+                {"to": "orm['contenttypes.ContentType']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "50"}),
         },
-        u"auth.user": {
+        "auth.user": {
             "Meta": {"object_name": "User"},
             "date_joined": (
                 "django.db.models.fields.DateTimeField",
@@ -90,10 +90,10 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Group']",
+                    "to": "orm['auth.Group']",
                 },
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "is_active": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -131,7 +131,7 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                 },
             ),
             "username": (
@@ -140,7 +140,7 @@ class Migration(SchemaMigration):
                 {"unique": "True", "max_length": "30"},
             ),
         },
-        u"contenttypes.contenttype": {
+        "contenttypes.contenttype": {
             "Meta": {
                 "ordering": "('name',)",
                 "unique_together": "(('app_label', 'model'),)",
@@ -152,11 +152,11 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "100"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "model": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.attachment": {
+        "helpdesk.attachment": {
             "Meta": {"ordering": "['filename']", "object_name": "Attachment"},
             "file": (
                 "django.db.models.fields.files.FileField",
@@ -171,9 +171,9 @@ class Migration(SchemaMigration):
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "mime_type": (
                 "django.db.models.fields.CharField",
                 [],
@@ -181,7 +181,7 @@ class Migration(SchemaMigration):
             ),
             "size": ("django.db.models.fields.IntegerField", [], {}),
         },
-        u"helpdesk.customfield": {
+        "helpdesk.customfield": {
             "Meta": {"object_name": "CustomField"},
             "data_type": (
                 "django.db.models.fields.CharField",
@@ -203,7 +203,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "label": ("django.db.models.fields.CharField", [], {"max_length": "'30'"}),
             "list_values": (
                 "django.db.models.fields.TextField",
@@ -228,14 +228,14 @@ class Migration(SchemaMigration):
             "required": ("django.db.models.fields.BooleanField", [], {}),
             "staff_only": ("django.db.models.fields.BooleanField", [], {}),
         },
-        u"helpdesk.emailtemplate": {
+        "helpdesk.emailtemplate": {
             "Meta": {
                 "ordering": "['template_name', 'locale']",
                 "object_name": "EmailTemplate",
             },
             "heading": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "html": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "locale": (
                 "django.db.models.fields.CharField",
                 [],
@@ -249,23 +249,23 @@ class Migration(SchemaMigration):
                 {"max_length": "100"},
             ),
         },
-        u"helpdesk.escalationexclusion": {
+        "helpdesk.escalationexclusion": {
             "Meta": {"object_name": "EscalationExclusion"},
             "date": ("django.db.models.fields.DateField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.followup": {
+        "helpdesk.followup": {
             "Meta": {"ordering": "['date']", "object_name": "FollowUp"},
             "comment": (
                 "django.db.models.fields.TextField",
@@ -277,7 +277,7 @@ class Migration(SchemaMigration):
                 [],
                 {"default": "datetime.datetime(2014, 9, 2, 0, 0)"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_status": (
                 "django.db.models.fields.IntegerField",
                 [],
@@ -291,7 +291,7 @@ class Migration(SchemaMigration):
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "title": (
                 "django.db.models.fields.CharField",
@@ -301,10 +301,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ignoreemail": {
+        "helpdesk.ignoreemail": {
             "Meta": {"object_name": "IgnoreEmail"},
             "date": ("django.db.models.fields.DateField", [], {"blank": "True"}),
             "email_address": (
@@ -312,7 +312,7 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "150"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "keep_in_mailbox": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -324,28 +324,28 @@ class Migration(SchemaMigration):
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.kbcategory": {
+        "helpdesk.kbcategory": {
             "Meta": {"ordering": "['title']", "object_name": "KBCategory"},
             "description": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.kbitem": {
+        "helpdesk.kbitem": {
             "Meta": {"ordering": "['title']", "object_name": "KBItem"},
             "answer": ("django.db.models.fields.TextField", [], {}),
             "category": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.KBCategory']"},
+                {"to": "orm['helpdesk.KBCategory']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_updated": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -360,23 +360,23 @@ class Migration(SchemaMigration):
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "votes": ("django.db.models.fields.IntegerField", [], {"default": "0"}),
         },
-        u"helpdesk.presetreply": {
+        "helpdesk.presetreply": {
             "Meta": {"ordering": "['name']", "object_name": "PreSetReply"},
             "body": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.queue": {
+        "helpdesk.queue": {
             "Meta": {"ordering": "('title',)", "object_name": "Queue"},
             "allow_email_submission": (
                 "django.db.models.fields.BooleanField",
@@ -443,7 +443,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "locale": (
                 "django.db.models.fields.CharField",
                 [],
@@ -462,9 +462,9 @@ class Migration(SchemaMigration):
                 {"max_length": "200", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.savedsearch": {
+        "helpdesk.savedsearch": {
             "Meta": {"object_name": "SavedSearch"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "query": ("django.db.models.fields.TextField", [], {}),
             "shared": (
                 "django.db.models.fields.BooleanField",
@@ -475,10 +475,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']"},
+                {"to": "orm['auth.User']"},
             ),
         },
-        u"helpdesk.ticket": {
+        "helpdesk.ticket": {
             "Meta": {"ordering": "('id',)", "object_name": "Ticket"},
             "assigned_to": (
                 "django.db.models.fields.related.ForeignKey",
@@ -487,7 +487,7 @@ class Migration(SchemaMigration):
                     "blank": "True",
                     "related_name": "'assigned_to'",
                     "null": "True",
-                    "to": u"orm['auth.User']",
+                    "to": "orm['auth.User']",
                 },
             ),
             "created": ("django.db.models.fields.DateTimeField", [], {"blank": "True"}),
@@ -501,7 +501,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_escalation": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -525,7 +525,7 @@ class Migration(SchemaMigration):
             "queue": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Queue']"},
+                {"to": "orm['helpdesk.Queue']"},
             ),
             "resolution": (
                 "django.db.models.fields.TextField",
@@ -540,7 +540,7 @@ class Migration(SchemaMigration):
             ),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
         },
-        u"helpdesk.ticketcc": {
+        "helpdesk.ticketcc": {
             "Meta": {"object_name": "TicketCC"},
             "can_update": ("django.db.models.fields.BooleanField", [], {}),
             "can_view": ("django.db.models.fields.BooleanField", [], {}),
@@ -549,27 +549,27 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "75", "null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketchange": {
+        "helpdesk.ticketchange": {
             "Meta": {"object_name": "TicketChange"},
             "field": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_value": (
                 "django.db.models.fields.TextField",
                 [],
@@ -581,18 +581,18 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketcustomfieldvalue": {
+        "helpdesk.ticketcustomfieldvalue": {
             "Meta": {"object_name": "TicketCustomFieldValue"},
             "field": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.CustomField']"},
+                {"to": "orm['helpdesk.CustomField']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "value": (
                 "django.db.models.fields.TextField",
@@ -600,7 +600,7 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketdependency": {
+        "helpdesk.ticketdependency": {
             "Meta": {
                 "unique_together": "(('ticket', 'depends_on'),)",
                 "object_name": "TicketDependency",
@@ -608,18 +608,18 @@ class Migration(SchemaMigration):
             "depends_on": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'depends_on'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'depends_on'", "to": "orm['helpdesk.Ticket']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'ticketdependency'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'ticketdependency'", "to": "orm['helpdesk.Ticket']"},
             ),
         },
-        u"helpdesk.usersettings": {
+        "helpdesk.usersettings": {
             "Meta": {"object_name": "UserSettings"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "settings_pickled": (
                 "django.db.models.fields.TextField",
                 [],
@@ -628,7 +628,7 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.OneToOneField",
                 [],
-                {"to": u"orm['auth.User']", "unique": "True"},
+                {"to": "orm['auth.User']", "unique": "True"},
             ),
         },
     }

--- a/web/helpdesk/south_migrations/0009_auto__chg_field_attachment_filename.py
+++ b/web/helpdesk/south_migrations/0009_auto__chg_field_attachment_filename.py
@@ -37,7 +37,7 @@ class Migration(SchemaMigration):
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                     "symmetrical": "False",
                     "blank": "True",
                 },
@@ -57,7 +57,7 @@ class Migration(SchemaMigration):
             "content_type": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['contenttypes.ContentType']"},
+                {"to": "orm['contenttypes.ContentType']"},
             ),
             "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "50"}),
@@ -86,7 +86,7 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Group']",
+                    "to": "orm['auth.Group']",
                 },
             ),
             "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
@@ -127,7 +127,7 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                 },
             ),
             "username": (
@@ -167,7 +167,7 @@ class Migration(SchemaMigration):
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
             "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "mime_type": (
@@ -248,20 +248,20 @@ class Migration(SchemaMigration):
         "helpdesk.escalationexclusion": {
             "Meta": {"object_name": "EscalationExclusion"},
             "date": ("django.db.models.fields.DateField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.followup": {
+        "helpdesk.followup": {
             "Meta": {"ordering": "['date']", "object_name": "FollowUp"},
             "comment": (
                 "django.db.models.fields.TextField",
@@ -273,7 +273,7 @@ class Migration(SchemaMigration):
                 [],
                 {"default": "datetime.datetime(2014, 9, 2, 0, 0)"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_status": (
                 "django.db.models.fields.IntegerField",
                 [],
@@ -287,7 +287,7 @@ class Migration(SchemaMigration):
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "title": (
                 "django.db.models.fields.CharField",
@@ -297,10 +297,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ignoreemail": {
+        "helpdesk.ignoreemail": {
             "Meta": {"object_name": "IgnoreEmail"},
             "date": ("django.db.models.fields.DateField", [], {"blank": "True"}),
             "email_address": (
@@ -308,7 +308,7 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "150"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "keep_in_mailbox": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -320,28 +320,28 @@ class Migration(SchemaMigration):
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.kbcategory": {
+        "helpdesk.kbcategory": {
             "Meta": {"ordering": "['title']", "object_name": "KBCategory"},
             "description": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.kbitem": {
+        "helpdesk.kbitem": {
             "Meta": {"ordering": "['title']", "object_name": "KBItem"},
             "answer": ("django.db.models.fields.TextField", [], {}),
             "category": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.KBCategory']"},
+                {"to": "orm['helpdesk.KBCategory']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_updated": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -356,23 +356,23 @@ class Migration(SchemaMigration):
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "votes": ("django.db.models.fields.IntegerField", [], {"default": "0"}),
         },
-        u"helpdesk.presetreply": {
+        "helpdesk.presetreply": {
             "Meta": {"ordering": "['name']", "object_name": "PreSetReply"},
             "body": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.queue": {
+        "helpdesk.queue": {
             "Meta": {"ordering": "('title',)", "object_name": "Queue"},
             "allow_email_submission": (
                 "django.db.models.fields.BooleanField",
@@ -439,7 +439,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "locale": (
                 "django.db.models.fields.CharField",
                 [],
@@ -458,9 +458,9 @@ class Migration(SchemaMigration):
                 {"max_length": "200", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.savedsearch": {
+        "helpdesk.savedsearch": {
             "Meta": {"object_name": "SavedSearch"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "query": ("django.db.models.fields.TextField", [], {}),
             "shared": (
                 "django.db.models.fields.BooleanField",
@@ -471,10 +471,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']"},
+                {"to": "orm['auth.User']"},
             ),
         },
-        u"helpdesk.ticket": {
+        "helpdesk.ticket": {
             "Meta": {"ordering": "('id',)", "object_name": "Ticket"},
             "assigned_to": (
                 "django.db.models.fields.related.ForeignKey",
@@ -483,7 +483,7 @@ class Migration(SchemaMigration):
                     "blank": "True",
                     "related_name": "'assigned_to'",
                     "null": "True",
-                    "to": u"orm['auth.User']",
+                    "to": "orm['auth.User']",
                 },
             ),
             "created": ("django.db.models.fields.DateTimeField", [], {"blank": "True"}),
@@ -497,7 +497,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_escalation": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -521,7 +521,7 @@ class Migration(SchemaMigration):
             "queue": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Queue']"},
+                {"to": "orm['helpdesk.Queue']"},
             ),
             "resolution": (
                 "django.db.models.fields.TextField",
@@ -536,7 +536,7 @@ class Migration(SchemaMigration):
             ),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
         },
-        u"helpdesk.ticketcc": {
+        "helpdesk.ticketcc": {
             "Meta": {"object_name": "TicketCC"},
             "can_update": ("django.db.models.fields.BooleanField", [], {}),
             "can_view": ("django.db.models.fields.BooleanField", [], {}),
@@ -545,27 +545,27 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "75", "null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketchange": {
+        "helpdesk.ticketchange": {
             "Meta": {"object_name": "TicketChange"},
             "field": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_value": (
                 "django.db.models.fields.TextField",
                 [],
@@ -577,18 +577,18 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketcustomfieldvalue": {
+        "helpdesk.ticketcustomfieldvalue": {
             "Meta": {"object_name": "TicketCustomFieldValue"},
             "field": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.CustomField']"},
+                {"to": "orm['helpdesk.CustomField']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "value": (
                 "django.db.models.fields.TextField",
@@ -596,7 +596,7 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketdependency": {
+        "helpdesk.ticketdependency": {
             "Meta": {
                 "unique_together": "(('ticket', 'depends_on'),)",
                 "object_name": "TicketDependency",
@@ -604,18 +604,18 @@ class Migration(SchemaMigration):
             "depends_on": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'depends_on'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'depends_on'", "to": "orm['helpdesk.Ticket']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'ticketdependency'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'ticketdependency'", "to": "orm['helpdesk.Ticket']"},
             ),
         },
-        u"helpdesk.usersettings": {
+        "helpdesk.usersettings": {
             "Meta": {"object_name": "UserSettings"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "settings_pickled": (
                 "django.db.models.fields.TextField",
                 [],
@@ -624,7 +624,7 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.OneToOneField",
                 [],
-                {"to": u"orm['auth.User']", "unique": "True"},
+                {"to": "orm['auth.User']", "unique": "True"},
             ),
         },
     }

--- a/web/helpdesk/south_migrations/0010_auto__add_field_queue_socks_proxy_type__add_field_queue_socks_proxy_ho.py
+++ b/web/helpdesk/south_migrations/0010_auto__add_field_queue_socks_proxy_type__add_field_queue_socks_proxy_ho.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         # Adding field 'Queue.socks_proxy_type'
         db.add_column(
-            u"helpdesk_queue",
+            "helpdesk_queue",
             "socks_proxy_type",
             self.gf("django.db.models.fields.CharField")(
                 max_length=8, null=True, blank=True
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
         # Adding field 'Queue.socks_proxy_host'
         db.add_column(
-            u"helpdesk_queue",
+            "helpdesk_queue",
             "socks_proxy_host",
             self.gf("django.db.models.fields.GenericIPAddressField")(
                 max_length=39, null=True, blank=True
@@ -29,7 +29,7 @@ class Migration(SchemaMigration):
 
         # Adding field 'Queue.socks_proxy_port'
         db.add_column(
-            u"helpdesk_queue",
+            "helpdesk_queue",
             "socks_proxy_port",
             self.gf("django.db.models.fields.IntegerField")(null=True, blank=True),
             keep_default=False,
@@ -37,18 +37,18 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Queue.socks_proxy_type'
-        db.delete_column(u"helpdesk_queue", "socks_proxy_type")
+        db.delete_column("helpdesk_queue", "socks_proxy_type")
 
         # Deleting field 'Queue.socks_proxy_host'
-        db.delete_column(u"helpdesk_queue", "socks_proxy_host")
+        db.delete_column("helpdesk_queue", "socks_proxy_host")
 
         # Deleting field 'Queue.socks_proxy_port'
-        db.delete_column(u"helpdesk_queue", "socks_proxy_port")
+        db.delete_column("helpdesk_queue", "socks_proxy_port")
 
     models = {
-        u"auth.group": {
+        "auth.group": {
             "Meta": {"object_name": "Group"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": (
                 "django.db.models.fields.CharField",
                 [],
@@ -58,13 +58,13 @@ class Migration(SchemaMigration):
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                     "symmetrical": "False",
                     "blank": "True",
                 },
             ),
         },
-        u"auth.permission": {
+        "auth.permission": {
             "Meta": {
                 "ordering": "(u'content_type__app_label', u'content_type__model', u'codename')",
                 "unique_together": "((u'content_type', u'codename'),)",
@@ -78,12 +78,12 @@ class Migration(SchemaMigration):
             "content_type": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['contenttypes.ContentType']"},
+                {"to": "orm['contenttypes.ContentType']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "50"}),
         },
-        u"auth.user": {
+        "auth.user": {
             "Meta": {"object_name": "User"},
             "date_joined": (
                 "django.db.models.fields.DateTimeField",
@@ -107,10 +107,10 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Group']",
+                    "to": "orm['auth.Group']",
                 },
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "is_active": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -148,7 +148,7 @@ class Migration(SchemaMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                 },
             ),
             "username": (
@@ -157,7 +157,7 @@ class Migration(SchemaMigration):
                 {"unique": "True", "max_length": "30"},
             ),
         },
-        u"contenttypes.contenttype": {
+        "contenttypes.contenttype": {
             "Meta": {
                 "ordering": "('name',)",
                 "unique_together": "(('app_label', 'model'),)",
@@ -169,11 +169,11 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "100"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "model": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.attachment": {
+        "helpdesk.attachment": {
             "Meta": {"ordering": "['filename']", "object_name": "Attachment"},
             "file": (
                 "django.db.models.fields.files.FileField",
@@ -188,9 +188,9 @@ class Migration(SchemaMigration):
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "mime_type": (
                 "django.db.models.fields.CharField",
                 [],
@@ -198,7 +198,7 @@ class Migration(SchemaMigration):
             ),
             "size": ("django.db.models.fields.IntegerField", [], {}),
         },
-        u"helpdesk.customfield": {
+        "helpdesk.customfield": {
             "Meta": {"object_name": "CustomField"},
             "data_type": (
                 "django.db.models.fields.CharField",
@@ -220,7 +220,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "label": ("django.db.models.fields.CharField", [], {"max_length": "'30'"}),
             "list_values": (
                 "django.db.models.fields.TextField",
@@ -253,14 +253,14 @@ class Migration(SchemaMigration):
                 {"default": "False"},
             ),
         },
-        u"helpdesk.emailtemplate": {
+        "helpdesk.emailtemplate": {
             "Meta": {
                 "ordering": "['template_name', 'locale']",
                 "object_name": "EmailTemplate",
             },
             "heading": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "html": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "locale": (
                 "django.db.models.fields.CharField",
                 [],
@@ -274,23 +274,23 @@ class Migration(SchemaMigration):
                 {"max_length": "100"},
             ),
         },
-        u"helpdesk.escalationexclusion": {
+        "helpdesk.escalationexclusion": {
             "Meta": {"object_name": "EscalationExclusion"},
             "date": ("django.db.models.fields.DateField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.followup": {
+        "helpdesk.followup": {
             "Meta": {"ordering": "['date']", "object_name": "FollowUp"},
             "comment": (
                 "django.db.models.fields.TextField",
@@ -302,7 +302,7 @@ class Migration(SchemaMigration):
                 [],
                 {"default": "datetime.datetime.now"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_status": (
                 "django.db.models.fields.IntegerField",
                 [],
@@ -316,7 +316,7 @@ class Migration(SchemaMigration):
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "title": (
                 "django.db.models.fields.CharField",
@@ -326,10 +326,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ignoreemail": {
+        "helpdesk.ignoreemail": {
             "Meta": {"object_name": "IgnoreEmail"},
             "date": ("django.db.models.fields.DateField", [], {"blank": "True"}),
             "email_address": (
@@ -337,7 +337,7 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "150"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "keep_in_mailbox": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -349,28 +349,28 @@ class Migration(SchemaMigration):
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.kbcategory": {
+        "helpdesk.kbcategory": {
             "Meta": {"ordering": "['title']", "object_name": "KBCategory"},
             "description": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.kbitem": {
+        "helpdesk.kbitem": {
             "Meta": {"ordering": "['title']", "object_name": "KBItem"},
             "answer": ("django.db.models.fields.TextField", [], {}),
             "category": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.KBCategory']"},
+                {"to": "orm['helpdesk.KBCategory']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_updated": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -385,23 +385,23 @@ class Migration(SchemaMigration):
             "title": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "votes": ("django.db.models.fields.IntegerField", [], {"default": "0"}),
         },
-        u"helpdesk.presetreply": {
+        "helpdesk.presetreply": {
             "Meta": {"ordering": "['name']", "object_name": "PreSetReply"},
             "body": ("django.db.models.fields.TextField", [], {}),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "queues": (
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
                     "symmetrical": "False",
-                    "to": u"orm['helpdesk.Queue']",
+                    "to": "orm['helpdesk.Queue']",
                     "null": "True",
                     "blank": "True",
                 },
             ),
         },
-        u"helpdesk.queue": {
+        "helpdesk.queue": {
             "Meta": {"ordering": "('title',)", "object_name": "Queue"},
             "allow_email_submission": (
                 "django.db.models.fields.BooleanField",
@@ -468,7 +468,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "locale": (
                 "django.db.models.fields.CharField",
                 [],
@@ -502,9 +502,9 @@ class Migration(SchemaMigration):
                 {"max_length": "200", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.savedsearch": {
+        "helpdesk.savedsearch": {
             "Meta": {"object_name": "SavedSearch"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "query": ("django.db.models.fields.TextField", [], {}),
             "shared": (
                 "django.db.models.fields.BooleanField",
@@ -515,10 +515,10 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']"},
+                {"to": "orm['auth.User']"},
             ),
         },
-        u"helpdesk.ticket": {
+        "helpdesk.ticket": {
             "Meta": {"ordering": "('id',)", "object_name": "Ticket"},
             "assigned_to": (
                 "django.db.models.fields.related.ForeignKey",
@@ -527,7 +527,7 @@ class Migration(SchemaMigration):
                     "blank": "True",
                     "related_name": "'assigned_to'",
                     "null": "True",
-                    "to": u"orm['auth.User']",
+                    "to": "orm['auth.User']",
                 },
             ),
             "created": ("django.db.models.fields.DateTimeField", [], {"blank": "True"}),
@@ -541,7 +541,7 @@ class Migration(SchemaMigration):
                 [],
                 {"null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "last_escalation": (
                 "django.db.models.fields.DateTimeField",
                 [],
@@ -565,7 +565,7 @@ class Migration(SchemaMigration):
             "queue": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Queue']"},
+                {"to": "orm['helpdesk.Queue']"},
             ),
             "resolution": (
                 "django.db.models.fields.TextField",
@@ -580,7 +580,7 @@ class Migration(SchemaMigration):
             ),
             "title": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
         },
-        u"helpdesk.ticketcc": {
+        "helpdesk.ticketcc": {
             "Meta": {"object_name": "TicketCC"},
             "can_update": (
                 "django.db.models.fields.BooleanField",
@@ -597,27 +597,27 @@ class Migration(SchemaMigration):
                 [],
                 {"max_length": "75", "null": "True", "blank": "True"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "user": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['auth.User']", "null": "True", "blank": "True"},
+                {"to": "orm['auth.User']", "null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketchange": {
+        "helpdesk.ticketchange": {
             "Meta": {"object_name": "TicketChange"},
             "field": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "followup": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.FollowUp']"},
+                {"to": "orm['helpdesk.FollowUp']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "new_value": (
                 "django.db.models.fields.TextField",
                 [],
@@ -629,18 +629,18 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketcustomfieldvalue": {
+        "helpdesk.ticketcustomfieldvalue": {
             "Meta": {"object_name": "TicketCustomFieldValue"},
             "field": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.CustomField']"},
+                {"to": "orm['helpdesk.CustomField']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['helpdesk.Ticket']"},
+                {"to": "orm['helpdesk.Ticket']"},
             ),
             "value": (
                 "django.db.models.fields.TextField",
@@ -648,7 +648,7 @@ class Migration(SchemaMigration):
                 {"null": "True", "blank": "True"},
             ),
         },
-        u"helpdesk.ticketdependency": {
+        "helpdesk.ticketdependency": {
             "Meta": {
                 "unique_together": "(('ticket', 'depends_on'),)",
                 "object_name": "TicketDependency",
@@ -656,18 +656,18 @@ class Migration(SchemaMigration):
             "depends_on": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'depends_on'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'depends_on'", "to": "orm['helpdesk.Ticket']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "ticket": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"related_name": "'ticketdependency'", "to": u"orm['helpdesk.Ticket']"},
+                {"related_name": "'ticketdependency'", "to": "orm['helpdesk.Ticket']"},
             ),
         },
-        u"helpdesk.usersettings": {
+        "helpdesk.usersettings": {
             "Meta": {"object_name": "UserSettings"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "settings_pickled": (
                 "django.db.models.fields.TextField",
                 [],
@@ -676,7 +676,7 @@ class Migration(SchemaMigration):
             "user": (
                 "django.db.models.fields.related.OneToOneField",
                 [],
-                {"to": u"orm['auth.User']", "unique": "True"},
+                {"to": "orm['auth.User']", "unique": "True"},
             ),
         },
     }

--- a/web/helpdesk/south_migrations/0011_populate_usersettings.py
+++ b/web/helpdesk/south_migrations/0011_populate_usersettings.py
@@ -55,7 +55,7 @@ class Migration(DataMigration):
                 "django.db.models.fields.related.ManyToManyField",
                 [],
                 {
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                     "symmetrical": "False",
                     "blank": "True",
                 },
@@ -75,12 +75,12 @@ class Migration(DataMigration):
             "content_type": (
                 "django.db.models.fields.related.ForeignKey",
                 [],
-                {"to": u"orm['contenttypes.ContentType']"},
+                {"to": "orm['contenttypes.ContentType']"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "50"}),
         },
-        u"auth.user": {
+        "auth.user": {
             "Meta": {"object_name": "User"},
             "date_joined": (
                 "django.db.models.fields.DateTimeField",
@@ -104,10 +104,10 @@ class Migration(DataMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Group']",
+                    "to": "orm['auth.Group']",
                 },
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "is_active": (
                 "django.db.models.fields.BooleanField",
                 [],
@@ -145,7 +145,7 @@ class Migration(DataMigration):
                     "symmetrical": "False",
                     "related_name": "u'user_set'",
                     "blank": "True",
-                    "to": u"orm['auth.Permission']",
+                    "to": "orm['auth.Permission']",
                 },
             ),
             "username": (
@@ -154,7 +154,7 @@ class Migration(DataMigration):
                 {"unique": "True", "max_length": "30"},
             ),
         },
-        u"contenttypes.contenttype": {
+        "contenttypes.contenttype": {
             "Meta": {
                 "ordering": "('name',)",
                 "unique_together": "(('app_label', 'model'),)",
@@ -166,13 +166,13 @@ class Migration(DataMigration):
                 [],
                 {"max_length": "100"},
             ),
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "model": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
             "name": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
         },
-        u"helpdesk.usersettings": {
+        "helpdesk.usersettings": {
             "Meta": {"object_name": "UserSettings"},
-            u"id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
+            "id": ("django.db.models.fields.AutoField", [], {"primary_key": "True"}),
             "settings_pickled": (
                 "django.db.models.fields.TextField",
                 [],
@@ -181,7 +181,7 @@ class Migration(DataMigration):
             "user": (
                 "django.db.models.fields.related.OneToOneField",
                 [],
-                {"to": u"orm['auth.User']", "unique": "True"},
+                {"to": "orm['auth.User']", "unique": "True"},
             ),
         },
     }

--- a/web/helpdesk/views/staff.py
+++ b/web/helpdesk/views/staff.py
@@ -1301,41 +1301,41 @@ def run_report(request, report):
     for ticket in report_queryset:
         if report == "userpriority":
             metric1 = "%s" % ticket.get_assigned_to
-            metric2 = u"%s" % ticket.get_priority_display()
+            metric2 = "%s" % ticket.get_priority_display()
 
         elif report == "userqueue":
-            metric1 = u"%s" % ticket.get_assigned_to
-            metric2 = u"%s" % ticket.queue.title
+            metric1 = "%s" % ticket.get_assigned_to
+            metric2 = "%s" % ticket.queue.title
 
         elif report == "userstatus":
-            metric1 = u"%s" % ticket.get_assigned_to
-            metric2 = u"%s" % ticket.get_status_display()
+            metric1 = "%s" % ticket.get_assigned_to
+            metric2 = "%s" % ticket.get_status_display()
 
         elif report == "usermonth":
-            metric1 = u"%s" % ticket.get_assigned_to
-            metric2 = u"%s %s" % (
+            metric1 = "%s" % ticket.get_assigned_to
+            metric2 = "%s %s" % (
                 month_name(ticket.db_date_created.month),
                 ticket.db_date_created.year,
             )
 
         elif report == "queuepriority":
-            metric1 = u"%s" % ticket.queue.title
-            metric2 = u"%s" % ticket.get_priority_display()
+            metric1 = "%s" % ticket.queue.title
+            metric2 = "%s" % ticket.get_priority_display()
 
         elif report == "queuestatus":
-            metric1 = u"%s" % ticket.queue.title
-            metric2 = u"%s" % ticket.get_status_display()
+            metric1 = "%s" % ticket.queue.title
+            metric2 = "%s" % ticket.get_status_display()
 
         elif report == "queuemonth":
-            metric1 = u"%s" % ticket.queue.title
-            metric2 = u"%s %s" % (
+            metric1 = "%s" % ticket.queue.title
+            metric2 = "%s %s" % (
                 month_name(ticket.db_date_created.month),
                 ticket.db_date_created.year,
             )
 
         elif report == "daysuntilticketclosedbymonth":
-            metric1 = u"%s" % ticket.queue.title
-            metric2 = u"%s %s" % (
+            metric1 = "%s" % ticket.queue.title
+            metric2 = "%s %s" % (
                 month_name(ticket.db_date_created.month),
                 ticket.db_date_created.year,
             )

--- a/world/dominion/models.py
+++ b/world/dominion/models.py
@@ -692,7 +692,7 @@ class PrestigeAdjustment(SharedMemoryModel):
 
         now = datetime.now()
         weeks = (now - self.adjusted_on).days // 7
-        decay_multiplier = PRESTIGE_DECAY_AMOUNT ** weeks
+        decay_multiplier = PRESTIGE_DECAY_AMOUNT**weeks
         return int(round(self.adjusted_by * decay_multiplier))
 
 

--- a/world/magic/advancement.py
+++ b/world/magic/advancement.py
@@ -62,7 +62,7 @@ class MagicAdvancementScript(Script, RunDateMixin):
         potential_factor = int(practitioner.potential ** (1 / 10.0))
 
         max_spend = min(
-            practitioner.potential / ((potential_factor ** 2) * 10),
+            practitioner.potential / ((potential_factor**2) * 10),
             practitioner.unspent_resonance,
         )
         nodes = practitioner.node_resonances.filter(practicing=True)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Updates
- set black version to 22.3.0, including reformatting the project files.  10 files were changed, which included some of the migrations for web/helpdesk due to them using Python 2 syntax such as u-strings and print without parentheses.  black 22.3.0 includes some formatting changes, including:
  - stripping out u-string prefixes (u"" becomes "")
  - compressing together ** operator usage if the left and right side are "simple" expressions, including nested attributes (function calls and the like retain a space on the left and the right operator)
- updated black workflow action to use python 3.8 and black 22.3.0
- requirements.txt updated to accommodate for library changes
  - pinned markupsafe to <2.1 as v2.1 of markupsafe removed code that our version of Jinja2 was importing
  - updated black to 22.3.0

- also specified Python 3.8 in the Dockerfile while I was at it


#### Motivation for adding to Arx
Because I care. <3

#### Other info (issues closed, discussion etc)
Pretend I'm dependabot, but not really.