### PR TITLE
Prevent pyenv files from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ settings.ini
 # emacs backup files
 \#*\#
 .\#*
+
+# pyenv files
+.python-version
+install-pyenv-win.ps1


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This just adds a few files that `pyenv` generates to gitignore. I had to install multiple python versions to test against Evennia's latest develop branch. Repo for pyenv if you're doing windows development: https://github.com/pyenv-win/pyenv-win

#### Motivation for adding to Arx
Allow pyenv to be used in local development.

