### PR TITLE
Fix static paths

### DIFF
--- a/web/help_topics/templates/help_topics/list.html
+++ b/web/help_topics/templates/help_topics/list.html
@@ -16,16 +16,16 @@
 	<div class="col-sm-6">
 	<figure class="text-center">
 	<figcaption><h1>Map of Central Arx</h1></figcaption>
-	<a href="/static/images/ailith_map_inner.jpg">
-	<img src="/static/images/ailith_map_inner.jpg" height='200' width='200' />
+	<a href="/static/website/images/ailith_map_inner.jpg">
+	<img src="/static/website/images/ailith_map_inner.jpg" height='200' width='200' />
 	</a>
 	</figure>
 	</div>
 	<div class="col-sm-6">
 	<figure class="text-center">
 	<figcaption><h1>Map of Outer Districts</h1></figcaption>
-	<a href="/static/images/ailith_map_outer.jpg">
-	<img src="/static/images/ailith_map_outer.jpg" height='200' width='200' />
+	<a href="/static/website/images/ailith_map_outer.jpg">
+	<img src="/static/website/images/ailith_map_outer.jpg" height='200' width='200' />
 	</a>
 	</figure>
 	</div>	
@@ -123,16 +123,16 @@
 	<div class="col-sm-6">
 	<figure class="text-center">
 	<figcaption><h2>Color Codes</h2></figcaption>
-	<a href="/static/images/xterm_chart.jpg">
-	<img src="/static/images/xterm_chart.jpg" height='200' width='200' />
+	<a href="/static/website/images/xterm_chart.jpg">
+	<img src="/static/website/images/xterm_chart.jpg" height='200' width='200' />
 	</a>
 	</figure>
 	</div>
 	<div class="col-sm-6">
 	<figure class="text-center">
 	<figcaption><h2>Modes of Address</h1></figcaption>
-	<a href="/static/images/modes_of_address.jpg">
-	<img src="/static/images/modes_of_address.jpg" height='200' width='200' />
+	<a href="/static/website/images/modes_of_address.jpg">
+	<img src="/static/website/images/modes_of_address.jpg" height='200' width='200' />
 	</a>
 	</figure>
 	</div>

--- a/web/template_overrides/website/base.html
+++ b/web/template_overrides/website/base.html
@@ -20,13 +20,13 @@
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 	
     {% if sidebar %}
-    <link rel="stylesheet" type="text/css" href="/static/css/prosimii-screen-alt.css" media="screen" title="Prosimii (Sidebar)" />
+    <link rel="stylesheet" type="text/css" href="{% static 'website/css/prosimii-screen-alt.css' %}" media="screen" title="Prosimii (Sidebar)" />
     {% else %}
-    <link rel="stylesheet" type="text/css" href="/static/css/prosimii-screen.css" media="screen" title="Prosimii" />
+    <link rel="stylesheet" type="text/css" href="{% static 'website/css/prosimii-screen.css' %}" media="screen" title="Prosimii" />
     
     {% endif %}
-    <link rel="stylesheet alternative" type="text/css" href="/static/css/prosimii-print.css" media="screen" title="Print Preview" />
-    <link rel="stylesheet" type="text/css" href="/static/css/prosimii-print.css" media="print" />
+    <link rel="stylesheet alternative" type="text/css" href="{% static 'website/css/prosimii-print.css' %}" media="screen" title="Print Preview" />
+    <link rel="stylesheet" type="text/css" href="{% static 'website/css/prosimii-print.css' %}" media="print" />
 
     {% block header_ext %}
     {% endblock %}
@@ -47,7 +47,7 @@
       </div>
 
       <div class="midHeader">
-        <img src="/static/images/arx_badge.png" height='100' width='100' align='left'/> <h1 class="headerTitle" lang="la">Arx, After the Reckoning</h1>
+        <img src="{% static 'website/images/arx_badge.png' %}" height='100' width='100' align='left'/> <h1 class="headerTitle" lang="la">Arx, After the Reckoning</h1>
         <div class="headerSubTitle" title="Slogan">
         <!-- Insert a slogan here if you want -->
         {{game_slogan}}			&nbsp;


### PR DESCRIPTION
After removing the static files from source control, it became apparent that there were a few resources with broke static paths in our templates - namely, css files and a few images. This resolves their paths so they load.