### PR TITLE
Ignore another fealty graph file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ world/dominion/map/arxmap_imagesize.cfg
 *.db3-wal
 
 # generated fealty graph
+world/dominion/fealty/fealty_graph
 world/dominion/fealty/fealty_graph.png
 world/dominion/fealty/fealty_graph_full.png
 


### PR DESCRIPTION
While playing around with static files I was surprised to see another fealty graph file generated without a file extension. This just adds it to gitignore to prevent it accidentally being committed.
