### PR TITLE
Infinite Loop protection in weather

### DIFF
--- a/world/weather/tests.py
+++ b/world/weather/tests.py
@@ -4,6 +4,7 @@ from world.weather.models import WeatherType, WeatherEmit
 from server.utils.test_utils import ArxCommandTest
 from world.weather import weather_commands, weather_script, utils
 from evennia.server.models import ServerConfig
+from unittest.mock import patch
 
 
 class TestWeatherCommands(ArxCommandTest):
@@ -46,10 +47,6 @@ class TestWeatherCommands(ArxCommandTest):
             "players to see a new weather emit.",
         )
 
-    def test_weather_utils(self):
-        new_weather, new_intensity = utils.advance_weather()
-        assert new_intensity < 5
-
     def test_choose_current_weather_max_attempts(self):
         # Set automated flag to False for all existing weather types
         for wt in WeatherType.objects.all():
@@ -64,9 +61,6 @@ class TestWeatherCommands(ArxCommandTest):
         # Set the weather type current to the new weather type ID and a high intensity
         ServerConfig.objects.conf(key="weather_type_current", value=self.weather3.id)
         ServerConfig.objects.conf(key="weather_intensity_current", value=999)
-
-        # Set max_attempts to 2 to force an exception to be raised
-        utils.MAX_ATTEMPTS = 2
 
         # Call choose_current_weather() and expect a WeatherSelectionError to be raised
         with self.assertRaises(utils.WeatherSelectionError):

--- a/world/weather/tests.py
+++ b/world/weather/tests.py
@@ -4,7 +4,6 @@ from world.weather.models import WeatherType, WeatherEmit
 from server.utils.test_utils import ArxCommandTest
 from world.weather import weather_commands, weather_script, utils
 from evennia.server.models import ServerConfig
-from unittest.mock import patch
 
 
 class TestWeatherCommands(ArxCommandTest):

--- a/world/weather/utils.py
+++ b/world/weather/utils.py
@@ -290,9 +290,13 @@ def choose_current_weather():
 
     weather_type = get_weather_type()
     weather_intensity = get_weather_intensity()
+    max_attempts = 10
+    # There wasn't any limitation in the original code
+    # Had an infinite loop as a result
 
     emit = pick_emit(weather_type, intensity=weather_intensity)
-    while not emit:
+    attempt_count = 0
+    while not emit and attempt_count < max_attempts:
         # Just in case there's no available weather for a given
         # target intensity of during our current season/time;
         # we'll advance the weather until we do have something.
@@ -304,7 +308,7 @@ def choose_current_weather():
         )
         weather_type, weather_intensity = advance_weather()
         emit = pick_emit(weather_type, intensity=weather_intensity)
-
+        attempt_count += 1
     ServerConfig.objects.conf(key="weather_last_emit", value=emit)
     return emit
 

--- a/world/weather/utils.py
+++ b/world/weather/utils.py
@@ -282,6 +282,10 @@ def advance_weather():
     return current_weather, current_intensity
 
 
+class WeatherSelectionError(Exception):
+    pass
+
+
 def choose_current_weather():
     """
     Picks a new emit for the current weather conditions, and locks it in.
@@ -309,6 +313,13 @@ def choose_current_weather():
         weather_type, weather_intensity = advance_weather()
         emit = pick_emit(weather_type, intensity=weather_intensity)
         attempt_count += 1
+    if not emit:
+        logger.log_err(
+            "Maximum number of attempts reached without finding a weather emit"
+        )
+        raise WeatherSelectionError(
+            "Maximum number of attempts reached without finding a weather emit"
+        )
     ServerConfig.objects.conf(key="weather_last_emit", value=emit)
     return emit
 


### PR DESCRIPTION
I added in a max number of 10 attempts to the while loop, and near as I can tell the script handles a none result for emit. Still not entirely certain how the error first started. I think the most likely culprit is weather was set in game, the script was deleted in django, tried to advance and found it no longer existed and couldn't reference any weather fields. It's hard for me to tell for sure, and checking with Herja to see if I can reproduce it locally.