### PR TITLE
Cast to decimal when receiving mail

### DIFF
--- a/world/msgs/handler_mixins/messengerhandler.py
+++ b/world/msgs/handler_mixins/messengerhandler.py
@@ -14,6 +14,7 @@ from world.msgs.managers import (
     reload_model_as_proxy,
 )
 from server.utils.arx_utils import get_date, create_arx_message, inform_staff
+from decimal import Decimal
 
 
 class MessengerHandler(MsgHandlerBase):
@@ -217,7 +218,7 @@ class MessengerHandler(MsgHandlerBase):
             self.msg("{wYou receive{n %s." % obj)
             obj.tags.remove("in transit")
         if money and money > 0:
-            self.obj.currency += money
+            self.obj.currency += Decimal(money)
             self.msg("{wYou receive %s silver coins.{n" % money)
         if mats:
             material, amt = mats


### PR DESCRIPTION
Got a TypeError because decimals and floats can't be added. The `__set__` of the descriptor does a cast, but a `+=` does an addition before the assignment, which is where the error occurs. I'd need to make some wrapper in the `__get__` method that returns some subclass of decimal that allows adding floats by casting them and that's too much to bother with